### PR TITLE
fix: work around aea-helpers bin-template-path crash in build-agent-runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -158,7 +158,7 @@ build-agent-runner: uv-install  agent
 	--hidden-import aea_ledger_cosmos \
 	--hidden-import aea_ledger_ethereum_flashbots \
 	$(shell uv run aea-helpers build-binary-deps ./agent) \
-	--onefile $(shell uv run aea-helpers bin-template-path) \
+	--onefile $(shell uv run python -c "import aea_helpers, os; print(os.path.join(os.path.dirname(aea_helpers.__file__), 'bin_template.py'))") \
 	--name agent_runner_bin
 	./dist/agent_runner_bin --version
 
@@ -176,7 +176,7 @@ build-agent-runner-mac: uv-install  agent
 	--hidden-import aea_ledger_cosmos \
 	--hidden-import aea_ledger_ethereum_flashbots \
 	$(shell uv run aea-helpers build-binary-deps ./agent) \
-	--onefile $(shell uv run aea-helpers bin-template-path) \
+	--onefile $(shell uv run python -c "import aea_helpers, os; print(os.path.join(os.path.dirname(aea_helpers.__file__), 'bin_template.py'))") \
 	--codesign-identity "${SIGN_ID}" \
 	--name agent_runner_bin
 	./dist/agent_runner_bin --help 1>/dev/null


### PR DESCRIPTION
## Problem

`open-aea-helpers` 0.21.17 / 0.21.18 / 0.21.19 ship a broken `bin-template-path` CLI command:

```
$ uv run aea-helpers bin-template-path
  File ".../aea_helpers/pyinstaller_deps.py", line 132, in bin_template_path
    from aea_helpers import bin_template
  File ".../aea_helpers/bin_template.py", line 41, in <module>
    validation_module._CUR_DIR = Path(sys._MEIPASS) / validation_module._CUR_DIR
AttributeError: module 'sys' has no attribute '_MEIPASS'
```

`bin_template.py` is a PyInstaller entry-point template that runs `Path(sys._MEIPASS)` at module top level — valid only inside a frozen bundle. `bin_template_path()` did `from aea_helpers import bin_template` just to read `__file__`, which crashes everywhere else.

Net effect on this repo's `make build-agent-runner`: `$(shell uv run aea-helpers bin-template-path)` expands to empty and pyinstaller errors with `pyinstaller: error: the following arguments are required: scriptname` — i.e. the PyInstaller build has been silently broken since the move to aea-helpers commands.

## Fix in this repo

Replace `$(shell uv run aea-helpers bin-template-path)` in both Makefile targets (`build-agent-runner`, `build-agent-runner-mac`) with a direct `python -c` that resolves the template path via `os.path.dirname(aea_helpers.__file__)` — no module import of the template itself.

## Upstream fix

Proper fix in open-autonomy: [valory-xyz/open-autonomy#2487](https://github.com/valory-xyz/open-autonomy/pull/2487). Once that lands in a released `open-aea-helpers`, this workaround can be reverted (~2-line revert).

## Test plan

Verified locally on a sibling repo (trader) using the same Makefile pattern and the same workaround:

- `make build-agent-runner` → 60 MB Mach-O arm64 `dist/agent_runner_bin`, `--version` succeeds.
- `make check-agent-runner` → `[OK] Found 'Starting AEA' within 80s`.

Identical two-line patch committed to trader in [valory-xyz/trader#911 @ 6e83379](https://github.com/valory-xyz/trader/pull/911/commits/6e833793) and optimus (forthcoming).

🤖 Generated with [Claude Code](https://claude.com/claude-code)