### PR TITLE
ci: add "All checks passed" meta job as single aggregate gate

### DIFF
--- a/.github/workflows/main_workflow.yml
+++ b/.github/workflows/main_workflow.yml
@@ -242,3 +242,20 @@ jobs:
           tar -xzf gitleaks_8.21.2_linux_x64.tar.gz && \
           sudo install gitleaks /usr/bin && \
           gitleaks detect --report-format json --report-path leak_report -v
+
+  all_checks_passed:
+    name: All checks passed
+    if: always()
+    needs:
+      - lock_check
+      - copyright_and_dependencies_check
+      - linter_checks
+      - test
+      - coverage
+      - scan
+    runs-on: ubuntu-24.04
+    timeout-minutes: 1
+    steps:
+      - name: Verify all dependent jobs succeeded
+        if: ${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') || contains(needs.*.result, 'skipped') }}
+        run: exit 1


### PR DESCRIPTION
## Summary

- Adds an `all_checks_passed` meta job (display name: `All checks passed`) to `main_workflow.yml` that aggregates the six mandatory CI jobs behind a single status context.
- `needs`: `lock_check`, `copyright_and_dependencies_check`, `linter_checks`, `test`, `coverage`, `scan`.
- `if: always()` so the job runs even when upstream jobs fail or are cancelled; it exits 1 if any dependency finished as `failure`, `cancelled`, or `skipped`.
- Required so branch protection on `main` can gate merges on a single check. When jobs are added/removed in the future, update this job's `needs` list instead of editing branch protection.

## Test plan

- [ ] CI runs on this PR; `All checks passed` turns green only after all six dependent jobs succeed.
- [ ] After merge, branch protection on `main` will be applied with `All checks passed` as the sole required status check (strict).

Co-Authored-By: Claude Opus 4.7 (1M context) &lt;noreply@anthropic.com&gt;
