### PR TITLE
fix(memeooorr_abci): emit NO_MAJORITY from CheckFundsRound

### DIFF
--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifngitemoxhahloctciywjzfmlhp373ijuvrocmwbyxl3bate2fne
 fingerprint_ignore_patterns: []
-agent: valory/memeooorr:0.1.0:bafybeia4uh5y3kjkyahqahg4aakrcpbadh7aqxf2wc62whbuylpwdsvlh4
+agent: valory/memeooorr:0.1.0:bafybeie7bf3z3txzm6g56jmiiulwz54impggt2vsawny4tlfok5sbjovia
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -5,12 +5,12 @@
         "connection/valory/twikit/0.1.0": "bafybeigpdbqkfvpa2huwafxme4vp2nctvoeiv7t35esv3d27c42synlina",
         "connection/valory/mirror_db/0.1.0": "bafybeicn4oia3pnceay3j2m6yegannr4nuledfjsoxjkorao6g4amjvpsa",
         "connection/valory/tweepy/0.1.0": "bafybeicnffj7fhf4rcbut677kabp773x6f5urq7ti6fpmq72d3gjhugwgy",
-        "skill/valory/memeooorr_abci/0.1.0": "bafybeiby547usrbk6wkfhrkibriy3q422zrigxier7jfiraqfykkka476y",
-        "skill/valory/memeooorr_chained_abci/0.1.0": "bafybeibcmspqbssm3b4u7asxcqrj3jf6ebsndfjrq4h5csgad7kptqqnqm",
+        "skill/valory/memeooorr_abci/0.1.0": "bafybeigwvne7p77uipnlvcwazhofxmzltyosrlrweyeju4u66ngsyyqjja",
+        "skill/valory/memeooorr_chained_abci/0.1.0": "bafybeif4laep3a7fe7hdky3qvmcknaafv556wmyxdpk4ugdz5dgi36lp6u",
         "skill/valory/agent_db_abci/0.1.0": "bafybeib72xypoji23z2xi6ms6h47izdoeihmwyzrpxlrobo2mej5sd22me",
-        "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeig35n2brh3pn757oqhx3dijqxowci5kkmllf7wzp42te6zffzgjbi",
-        "agent/valory/memeooorr/0.1.0": "bafybeia4uh5y3kjkyahqahg4aakrcpbadh7aqxf2wc62whbuylpwdsvlh4",
-        "service/dvilela/memeooorr/0.1.0": "bafybeibuxjibkd7n6wirxvedgjcsqhv5zuslo7lhqrua2amvw36ceqxhwu"
+        "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeihhp6vpmpjrwyggq4xacgeoge4el5sglyt7feadaa5wgfjheptr5q",
+        "agent/valory/memeooorr/0.1.0": "bafybeie7bf3z3txzm6g56jmiiulwz54impggt2vsawny4tlfok5sbjovia",
+        "service/dvilela/memeooorr/0.1.0": "bafybeiabrqsf3kt6fegiru4ddgazh4yfuajpzcnr55yqspo4acfevkm5aa"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/memeooorr/aea-config.yaml
+++ b/packages/valory/agents/memeooorr/aea-config.yaml
@@ -44,11 +44,11 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeiemyjkxj2ifzjr5kubtebpyezocl33zxt7gwf7yongg6zlbfjilte
 - valory/registration_abci:0.1.0:bafybeidywralavqvrmzxomdgnthngqfzhbpop6n23pwf67lg2p6ndvt3fy
 - valory/reset_pause_abci:0.1.0:bafybeiahbkc4gfcmcvifbs6dvhtcj6wtjr7bvvdxunhxxquglkv365lu3e
-- valory/memeooorr_abci:0.1.0:bafybeiby547usrbk6wkfhrkibriy3q422zrigxier7jfiraqfykkka476y
-- valory/memeooorr_chained_abci:0.1.0:bafybeibcmspqbssm3b4u7asxcqrj3jf6ebsndfjrq4h5csgad7kptqqnqm
+- valory/memeooorr_abci:0.1.0:bafybeigwvne7p77uipnlvcwazhofxmzltyosrlrweyeju4u66ngsyyqjja
+- valory/memeooorr_chained_abci:0.1.0:bafybeif4laep3a7fe7hdky3qvmcknaafv556wmyxdpk4ugdz5dgi36lp6u
 - valory/mech_interact_abci:0.1.0:bafybeidq4vfhz5hvixmzor4epnnh2xzhhzedcxhxfoa6nqgqjp3yqhktdu
 - valory/agent_db_abci:0.1.0:bafybeib72xypoji23z2xi6ms6h47izdoeihmwyzrpxlrobo2mej5sd22me
-- valory/agent_performance_summary_abci:0.1.0:bafybeig35n2brh3pn757oqhx3dijqxowci5kkmllf7wzp42te6zffzgjbi
+- valory/agent_performance_summary_abci:0.1.0:bafybeihhp6vpmpjrwyggq4xacgeoge4el5sglyt7feadaa5wgfjheptr5q
 - valory/funds_manager:0.1.0:bafybeiebmb72sxx3odmxzpn7qy4la3i6n5vf4di4vbkt4mt4kuybosftay
 default_ledger: ethereum
 required_ledgers:

--- a/packages/valory/skills/agent_performance_summary_abci/skill.yaml
+++ b/packages/valory/skills/agent_performance_summary_abci/skill.yaml
@@ -24,7 +24,7 @@ fingerprint_ignore_patterns: []
 contracts: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeiesqybjt2d3cwazu5xurye7znnkidem2qhudfvjnaprbk6p5flfe4
-- valory/memeooorr_abci:0.1.0:bafybeiby547usrbk6wkfhrkibriy3q422zrigxier7jfiraqfykkka476y
+- valory/memeooorr_abci:0.1.0:bafybeigwvne7p77uipnlvcwazhofxmzltyosrlrweyeju4u66ngsyyqjja
 handlers:
   abci:
     args: {}

--- a/packages/valory/skills/memeooorr_abci/rounds.py
+++ b/packages/valory/skills/memeooorr_abci/rounds.py
@@ -705,6 +705,10 @@ class CheckFundsRound(CollectSameUntilThresholdRound):
             if payload.event == Event.DONE.value:
                 return self.synchronized_data, Event.DONE
 
+        if not self.is_majority_possible(
+            self.collection, self.synchronized_data.nb_participants
+        ):
+            return self.synchronized_data, Event.NO_MAJORITY
         return None
 
 

--- a/packages/valory/skills/memeooorr_abci/skill.yaml
+++ b/packages/valory/skills/memeooorr_abci/skill.yaml
@@ -28,7 +28,7 @@ fingerprint:
   models.py: bafybeiegojfhmguimgljre4vw3u5lkenyr4r4fv75g6i2j2mb45a65spci
   payloads.py: bafybeigsubasnmooyxclbm4byalkj5ctwksbgekujzackgy7v4xx75rmxm
   prompts.py: bafybeifnelzscaj6vno42jkpgiiyj5y3u5qakrek4j3cns34gpjeryc5ty
-  rounds.py: bafybeihfj56gwv4gf7mrxxxcarbzv7uemuxfo7ro36b23xkzgrkyggwwmm
+  rounds.py: bafybeie2o2yzi6v7ypxutscwcu626cuyczztz6qqv36vat6ozjkuuroxui
   rounds_info.py: bafybeic3lo56wclkjino5g4p76ek4db5ei7qjbnu5gvtfjdlqu7fk2v62i
   tests/__init__.py: bafybeiep2skhj742bdjbvelskxhshtxofngkmqkb5zrplger6v372pgyai
   tests/conftest.py: bafybeigysaw5xdif5aucgk66p2d7zmrzerigkta4sbvil24oa5l34vywce
@@ -41,7 +41,7 @@ fingerprint:
   tests/test_handlers.py: bafybeiex2dqhod3vfggoes3uhfmsi4xx4u6jizzpj7rgx3xuuzzha3blrq
   tests/test_models.py: bafybeiajv7wsqx6p4a5klcvoepg2watg7etgoi4ucjul3cjayx4gosccmu
   tests/test_prompts.py: bafybeibmdio3tk5fzw2s4ch2fpbugb2z3nfmuo72yo2jnh4dapjtpuhbhq
-  tests/test_rounds.py: bafybeielamakggfrryf67raqy6pazwymofng6v4c5m2zknyo5ib66qzkau
+  tests/test_rounds.py: bafybeihexc5cmku2cqf3xhwzlmwespvvpfyr6glfibacv4vtlawzawjxeu
   tests/test_rounds_info.py: bafybeig7ctx7xngtlhdmvfyrvmddsz74py6g6recmesrshw6dgibgi32zy
 fingerprint_ignore_patterns: []
 connections:

--- a/packages/valory/skills/memeooorr_abci/tests/test_rounds.py
+++ b/packages/valory/skills/memeooorr_abci/tests/test_rounds.py
@@ -1211,13 +1211,7 @@ class TestActionTweetRound:
 
 
 class TestCheckFundsRound(MemeooorrRoundTestBase):
-    """Tests for CheckFundsRound.
-
-    Note: CheckFundsRound.end_block() doesn't handle NO_MAJORITY explicitly
-    (returns None when threshold not reached), so we can't use the standard
-    framework _test_round which expects NO_MAJORITY handling. Tests use
-    direct payload processing instead.
-    """
+    """Tests for CheckFundsRound."""
 
     def _run_check_funds_round(self, event: str, check_funds_count: int) -> Any:
         """Run a CheckFundsRound to completion and return end_block result."""
@@ -1263,12 +1257,20 @@ class TestCheckFundsRound(MemeooorrRoundTestBase):
         assert result is None
 
     def test_round_none_threshold_not_reached(self) -> None:
-        """Test round returns None when threshold not reached."""
+        """Test round returns None when threshold not reached and majority is still possible."""
         test_round = CheckFundsRound(
             synchronized_data=self.synchronized_data,
             context=self.context_mock,
         )
         assert test_round.end_block() is None
+
+    def test_round_no_majority_event(self) -> None:
+        """Test round emits NO_MAJORITY when consensus is unreachable."""
+        test_round = CheckFundsRound(
+            synchronized_data=self.synchronized_data,
+            context=self.context_mock,
+        )
+        self._test_no_majority_event(test_round)
 
 
 class TestPostTxDecisionMakingRound:

--- a/packages/valory/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/valory/skills/memeooorr_chained_abci/skill.yaml
@@ -27,9 +27,9 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeiahbkc4gfcmcvifbs6dvhtcj6wtjr7bvvdxunhxxquglkv365lu3e
 - valory/transaction_settlement_abci:0.1.0:bafybeiemyjkxj2ifzjr5kubtebpyezocl33zxt7gwf7yongg6zlbfjilte
 - valory/termination_abci:0.1.0:bafybeic7wo6vp7ag2yhirxgftim6mjmo225v2lixfxuj5q6rdp7mj6ujqy
-- valory/memeooorr_abci:0.1.0:bafybeiby547usrbk6wkfhrkibriy3q422zrigxier7jfiraqfykkka476y
+- valory/memeooorr_abci:0.1.0:bafybeigwvne7p77uipnlvcwazhofxmzltyosrlrweyeju4u66ngsyyqjja
 - valory/mech_interact_abci:0.1.0:bafybeidq4vfhz5hvixmzor4epnnh2xzhhzedcxhxfoa6nqgqjp3yqhktdu
-- valory/agent_performance_summary_abci:0.1.0:bafybeig35n2brh3pn757oqhx3dijqxowci5kkmllf7wzp42te6zffzgjbi
+- valory/agent_performance_summary_abci:0.1.0:bafybeihhp6vpmpjrwyggq4xacgeoge4el5sglyt7feadaa5wgfjheptr5q
 behaviours:
   main:
     args: {}


### PR DESCRIPTION
## Summary
- `CheckFundsRound.end_block()` returned `None` on failed consensus, leaving the wired `Event.NO_MAJORITY: CheckFundsRound` self-loop unreachable.
- Added the standard `is_majority_possible` guard so the round emits `NO_MAJORITY` immediately instead of waiting for `ROUND_TIMEOUT` to recover.
- Brings `CheckFundsRound` in line with the other 11 `CollectSameUntilThresholdRound` subclasses in the skill.
- Closes #58.

## Test plan
- [x] `pytest TestCheckFundsRound` (7 passed, includes new `test_round_no_majority_event`)
- [x] `pytest test_rounds.py` (114 passed, no regressions)
- [x] `tox -e black-check`, `isort-check`, `flake8`, `mypy`, `pylint`
- [x] `tox -e check-abciapp-specs` (FSM specs consistent)
- [x] `tox -e check-hash`, `check-packages`, `check-third-party-hashes`, `check-doc-hashes`, `check-dependencies`
- [x] `autonomy packages lock --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)