### PR TITLE
fix: bump dev-package YAML deps to OA 0.21.20 / OAEA 2.2.3

### DIFF
--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifngitemoxhahloctciywjzfmlhp373ijuvrocmwbyxl3bate2fne
 fingerprint_ignore_patterns: []
-agent: valory/memeooorr:0.1.0:bafybeigutqsw6ekvzwns4fwmqq27mvel4rpg5bedcxd3ncri3vbg7q2irq
+agent: valory/memeooorr:0.1.0:bafybeiaholpuutusise3rmjsplrtxsrixmbvnr5q7r5a4cgjfov3sq7bpi
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -1,16 +1,16 @@
 {
     "dev": {
-        "contract/valory/meme_factory/0.1.0": "bafybeifus4srfeqjy57y64es2ny3w3qeawtsnjwtcs66mosrapebklzsbq",
-        "contract/valory/service_registry_l2/0.1.0": "bafybeiahapgkem23imimvx3nmov553xix4uyno2lqb7t5t5fl5oesg7vnu",
+        "contract/valory/meme_factory/0.1.0": "bafybeiesostg2s5tcci2iovzapssbio5bzvgcoa7g2dton6a2kd36ndeya",
+        "contract/valory/service_registry_l2/0.1.0": "bafybeiagvunee7lwm3nhiel2wbtieknltb76j5o2gbvakzz6cxjobaidki",
         "connection/valory/twikit/0.1.0": "bafybeidruneqzx5hyr6w2rs2fyyflhiqt2ituuyouxr3x5zl3forzjbqn4",
         "connection/valory/mirror_db/0.1.0": "bafybeibjq4b2jd7ds24j7is7nvoof54ht5c7yhdz4e44xawpnrksu5dzb4",
         "connection/valory/tweepy/0.1.0": "bafybeihaz3cx7sypsrpqescha3hg35jlr7jylczwfgjoivl5jayjhnjuwe",
-        "skill/valory/memeooorr_abci/0.1.0": "bafybeig5l4u6hylm6ghthqdkbknkinw2xksdd5ha2rkwdq7sx6bfzaa65a",
-        "skill/valory/memeooorr_chained_abci/0.1.0": "bafybeihmlhfuf6twd6b2isnrt4sz2xro4wte4acz3pru3qa2afvgfszdsu",
+        "skill/valory/memeooorr_abci/0.1.0": "bafybeieoe2x2t663ued4fjfbzp7bqvniqgqhhqjecctk7lzvysvqdx5byu",
+        "skill/valory/memeooorr_chained_abci/0.1.0": "bafybeiemkpbfydc2h4wbdvc2pieq22xk52oz4aqglp2ffu6lufb3rllv2y",
         "skill/valory/agent_db_abci/0.1.0": "bafybeifevqsu4vxfchjh73q3kk4tflabhe6si67octhnxqcnwictvz3uzm",
-        "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeia547ya3tuwclfbkffbsglxlp5f5wpesjljnipncpatewi6vqj2ay",
-        "agent/valory/memeooorr/0.1.0": "bafybeigutqsw6ekvzwns4fwmqq27mvel4rpg5bedcxd3ncri3vbg7q2irq",
-        "service/dvilela/memeooorr/0.1.0": "bafybeibs7ao7inko5mf6j7v6364rh4ggivhst7s2a5gbxjgzvleqbcjeqq"
+        "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeicrs2hijyqf227ys62ms2pnrzzniqtkmyub4mjrdnhobhskohacj4",
+        "agent/valory/memeooorr/0.1.0": "bafybeiaholpuutusise3rmjsplrtxsrixmbvnr5q7r5a4cgjfov3sq7bpi",
+        "service/dvilela/memeooorr/0.1.0": "bafybeier6rko4spomv4gdzhplo65ykdcbsxtdomuoijp4okgkirmtxo66y"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/memeooorr/aea-config.yaml
+++ b/packages/valory/agents/memeooorr/aea-config.yaml
@@ -22,8 +22,8 @@ contracts:
 - valory/gnosis_safe:0.1.0:bafybeihfmmoyk7tfh6xg5ylqnxpsxqgzgwklablc3zonp55sz6b2vzuzue
 - valory/gnosis_safe_proxy_factory:0.1.0:bafybeicutxdhfofyqt3l2y4udiqgfh22n3sn6fl2i5r7txd2kctvuig4e4
 - valory/multisend:0.1.0:bafybeidwr3l2t564gle533l7elroxr77wvmqogdmwz4e6mmqxnbqsk37tm
-- valory/meme_factory:0.1.0:bafybeifus4srfeqjy57y64es2ny3w3qeawtsnjwtcs66mosrapebklzsbq
-- valory/service_registry_l2:0.1.0:bafybeiahapgkem23imimvx3nmov553xix4uyno2lqb7t5t5fl5oesg7vnu
+- valory/meme_factory:0.1.0:bafybeiesostg2s5tcci2iovzapssbio5bzvgcoa7g2dton6a2kd36ndeya
+- valory/service_registry_l2:0.1.0:bafybeiagvunee7lwm3nhiel2wbtieknltb76j5o2gbvakzz6cxjobaidki
 - valory/staking_token:0.1.0:bafybeic6rlrsdgo5my3nxiy247njlsn2tupodhcehxqis6dpfyz325bdp4
 - valory/staking_activity_checker:0.1.0:bafybeideqqajn76jxdukqcyl4ear5mwjnc25zpko75u236afiimhm6imba
 protocols:
@@ -44,11 +44,11 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeigiojqgbi54jhree3sqrzaudbmjxb7y2ete74bbliryi3t7ztwi5q
 - valory/registration_abci:0.1.0:bafybeietlh4pq5wjsb6srpsqehcq3gwsod5c6gs4jdiwpzkgrwyxhbbbvq
 - valory/reset_pause_abci:0.1.0:bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa
-- valory/memeooorr_abci:0.1.0:bafybeig5l4u6hylm6ghthqdkbknkinw2xksdd5ha2rkwdq7sx6bfzaa65a
-- valory/memeooorr_chained_abci:0.1.0:bafybeihmlhfuf6twd6b2isnrt4sz2xro4wte4acz3pru3qa2afvgfszdsu
+- valory/memeooorr_abci:0.1.0:bafybeieoe2x2t663ued4fjfbzp7bqvniqgqhhqjecctk7lzvysvqdx5byu
+- valory/memeooorr_chained_abci:0.1.0:bafybeiemkpbfydc2h4wbdvc2pieq22xk52oz4aqglp2ffu6lufb3rllv2y
 - valory/mech_interact_abci:0.1.0:bafybeiburftv5nj5427qyue2f5sx56fpfskalnplwoow2ixqbvgio3kfky
 - valory/agent_db_abci:0.1.0:bafybeifevqsu4vxfchjh73q3kk4tflabhe6si67octhnxqcnwictvz3uzm
-- valory/agent_performance_summary_abci:0.1.0:bafybeia547ya3tuwclfbkffbsglxlp5f5wpesjljnipncpatewi6vqj2ay
+- valory/agent_performance_summary_abci:0.1.0:bafybeicrs2hijyqf227ys62ms2pnrzzniqtkmyub4mjrdnhobhskohacj4
 - valory/funds_manager:0.1.0:bafybeihuwnkgrhqixl4zj55fz2awptmpmdnmub2uzkgbx7rve7bnhkkl5i
 default_ledger: ethereum
 required_ledgers:
@@ -83,7 +83,7 @@ logging_config:
 skill_exception_policy: stop_and_exit
 dependencies:
   open-aea-ledger-ethereum:
-    version: ==2.2.1
+    version: ==2.2.3
   typing_extensions:
     version: '>=3.10.0.2'
 default_connection: null

--- a/packages/valory/contracts/meme_factory/contract.yaml
+++ b/packages/valory/contracts/meme_factory/contract.yaml
@@ -23,9 +23,9 @@ dependencies:
   eth_typing: {}
   hexbytes: {}
   open-aea-ledger-ethereum:
-    version: ==2.2.1
+    version: ==2.2.3
   open-aea-test-autonomy:
-    version: ==0.21.19
+    version: ==0.21.20
   packaging: {}
   requests:
     version: '>=2.28.1,<2.33.0'

--- a/packages/valory/contracts/service_registry_l2/contract.yaml
+++ b/packages/valory/contracts/service_registry_l2/contract.yaml
@@ -23,9 +23,9 @@ dependencies:
   eth_typing: {}
   hexbytes: {}
   open-aea-ledger-ethereum:
-    version: ==2.2.1
+    version: ==2.2.3
   open-aea-test-autonomy:
-    version: ==0.21.19
+    version: ==0.21.20
   packaging: {}
   requests:
     version: '>=2.28.1,<2.33.0'

--- a/packages/valory/skills/agent_performance_summary_abci/skill.yaml
+++ b/packages/valory/skills/agent_performance_summary_abci/skill.yaml
@@ -24,7 +24,7 @@ fingerprint_ignore_patterns: []
 contracts: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeidpod4inivvvgzenx46whshq4mzmxgwsxinv6ibdvyemkstam2yz4
-- valory/memeooorr_abci:0.1.0:bafybeig5l4u6hylm6ghthqdkbknkinw2xksdd5ha2rkwdq7sx6bfzaa65a
+- valory/memeooorr_abci:0.1.0:bafybeieoe2x2t663ued4fjfbzp7bqvniqgqhhqjecctk7lzvysvqdx5byu
 handlers:
   abci:
     args: {}

--- a/packages/valory/skills/memeooorr_abci/skill.yaml
+++ b/packages/valory/skills/memeooorr_abci/skill.yaml
@@ -51,8 +51,8 @@ connections:
 - valory/http_server:0.22.0:bafybeihs6dufyaa5l4uorplzx3wiyna5qlq2x43tmyl3yonkl265vspdle
 contracts:
 - valory/gnosis_safe:0.1.0:bafybeihfmmoyk7tfh6xg5ylqnxpsxqgzgwklablc3zonp55sz6b2vzuzue
-- valory/meme_factory:0.1.0:bafybeifus4srfeqjy57y64es2ny3w3qeawtsnjwtcs66mosrapebklzsbq
-- valory/service_registry_l2:0.1.0:bafybeiahapgkem23imimvx3nmov553xix4uyno2lqb7t5t5fl5oesg7vnu
+- valory/meme_factory:0.1.0:bafybeiesostg2s5tcci2iovzapssbio5bzvgcoa7g2dton6a2kd36ndeya
+- valory/service_registry_l2:0.1.0:bafybeiagvunee7lwm3nhiel2wbtieknltb76j5o2gbvakzz6cxjobaidki
 - valory/staking_token:0.1.0:bafybeic6rlrsdgo5my3nxiy247njlsn2tupodhcehxqis6dpfyz325bdp4
 - valory/staking_activity_checker:0.1.0:bafybeideqqajn76jxdukqcyl4ear5mwjnc25zpko75u236afiimhm6imba
 - valory/agent_mech:0.1.0:bafybeibdig2phm4hmquta6msnuhpb5y6btcvikpjzlmbz76bqxhsboppqm

--- a/packages/valory/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/valory/skills/memeooorr_chained_abci/skill.yaml
@@ -27,9 +27,9 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa
 - valory/transaction_settlement_abci:0.1.0:bafybeigiojqgbi54jhree3sqrzaudbmjxb7y2ete74bbliryi3t7ztwi5q
 - valory/termination_abci:0.1.0:bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu
-- valory/memeooorr_abci:0.1.0:bafybeig5l4u6hylm6ghthqdkbknkinw2xksdd5ha2rkwdq7sx6bfzaa65a
+- valory/memeooorr_abci:0.1.0:bafybeieoe2x2t663ued4fjfbzp7bqvniqgqhhqjecctk7lzvysvqdx5byu
 - valory/mech_interact_abci:0.1.0:bafybeiburftv5nj5427qyue2f5sx56fpfskalnplwoow2ixqbvgio3kfky
-- valory/agent_performance_summary_abci:0.1.0:bafybeia547ya3tuwclfbkffbsglxlp5f5wpesjljnipncpatewi6vqj2ay
+- valory/agent_performance_summary_abci:0.1.0:bafybeicrs2hijyqf227ys62ms2pnrzzniqtkmyub4mjrdnhobhskohacj4
 behaviours:
   main:
     args: {}


### PR DESCRIPTION
## Summary

The wave-2a migration ([#57](https://github.com/valory-xyz/meme-ooorr/pull/57)) bumped `pyproject.toml` to `open-autonomy[cli]==0.21.20` / `open-aea-*==2.2.3` but missed the `dependencies:` blocks in three dev-package YAMLs that still pinned the prior `==0.21.19` / `==2.2.1` versions:

- `packages/valory/agents/memeooorr/aea-config.yaml`
- `packages/valory/contracts/meme_factory/contract.yaml`
- `packages/valory/contracts/service_registry_l2/contract.yaml`

The mismatch surfaces at agent boot as:
```
Conflict on package open-aea-ledger-ethereum: specifier set '==2.2.1,==2.2.3' not satisfiable.
Terminating tendermint...
```
because the merged YAML deps from all loaded packages get fed into a single resolver pass.

## Fix

Bring all three up to `==0.21.20` / `==2.2.3` and re-lock fingerprints via `autonomy packages lock` (5 dev fingerprints regenerate transitively).

## Test plan

- [x] `tomte tox -e check-hash -e check-packages -e check-dependencies -e check-third-party-hashes`
- [x] No `==0.21.19` / `==2.2.1` left in dev-package YAMLs (verified with grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)