### PR TITLE
fix(release): bump OA 0.21.18 → 0.21.20 in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,7 +19,7 @@ jobs:
           python-version: ${{ matrix.python-versions }}
       - uses: addnab/docker-run-action@v3
         with:
-          image: valory/open-autonomy-user:0.21.18
+          image: valory/open-autonomy-user:0.21.20
           options: -v ${{ github.workspace }}:/work
           run: |
             echo "Pushing Packages"
@@ -45,7 +45,7 @@ jobs:
       - name: Set up tag and vars
         uses: addnab/docker-run-action@v3
         with:
-          image: valory/open-autonomy-user:0.21.18
+          image: valory/open-autonomy-user:0.21.20
           options: -v ${{ github.workspace }}:/work
           run: |
             echo "Setting Tag Images"
@@ -69,7 +69,7 @@ jobs:
       - uses: addnab/docker-run-action@v3
         name: Build Images
         with:
-          image: valory/open-autonomy-user:0.21.18
+          image: valory/open-autonomy-user:0.21.20
           options: -v ${{ github.workspace }}:/work -e DOCKER_USER -e DOCKER_PASSWORD
           shell: bash
           run: |
@@ -83,7 +83,7 @@ jobs:
             cd $SERVICE || exit 1
             echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin || exit 1
             docker buildx create --name multiarch-builder --driver docker-container --bootstrap --use
-            autonomy build-image --builder multiarch-builder --platform linux/amd64 --pre-install-command "apt update && apt upgrade -y && apt install -y libffi-dev libssl-dev" -e open-autonomy==0.21.18 --version $VERSION-amd64 --push || exit 1
+            autonomy build-image --builder multiarch-builder --platform linux/amd64 --pre-install-command "apt update && apt upgrade -y && apt install -y libffi-dev libssl-dev" -e open-autonomy==0.21.20 --version $VERSION-amd64 --push || exit 1
 
   publish-images-arm:
     name: Publish Docker Images (arm64 + arm/v7)
@@ -101,7 +101,7 @@ jobs:
       - name: Set up tag and vars
         uses: addnab/docker-run-action@v3
         with:
-          image: valory/open-autonomy-user:0.21.18
+          image: valory/open-autonomy-user:0.21.20
           options: -v ${{ github.workspace }}:/work
           run: |
             echo "Setting Tag Images"
@@ -125,7 +125,7 @@ jobs:
       - uses: addnab/docker-run-action@v3
         name: Build Images
         with:
-          image: valory/open-autonomy-user:0.21.18
+          image: valory/open-autonomy-user:0.21.20
           options: -v ${{ github.workspace }}:/work -e DOCKER_USER -e DOCKER_PASSWORD
           shell: bash
           run: |
@@ -139,7 +139,7 @@ jobs:
             cd $SERVICE || exit 1
             echo $DOCKER_PASSWORD | docker login -u $DOCKER_USER --password-stdin || exit 1
             docker buildx create --name multiarch-builder --driver docker-container --bootstrap --use
-            autonomy build-image --builder multiarch-builder --platform linux/arm64,linux/arm/v7 --pre-install-command "apt update && apt upgrade -y && apt install -y libffi-dev libssl-dev" -e open-autonomy==0.21.18 --version $VERSION-arm --push || exit 1
+            autonomy build-image --builder multiarch-builder --platform linux/arm64,linux/arm/v7 --pre-install-command "apt update && apt upgrade -y && apt install -y libffi-dev libssl-dev" -e open-autonomy==0.21.20 --version $VERSION-arm --push || exit 1
 
   merge-image-manifests:
     name: Merge Multi-arch Image Manifests
@@ -154,7 +154,7 @@ jobs:
       - name: Set up tag and vars
         uses: addnab/docker-run-action@v3
         with:
-          image: valory/open-autonomy-user:0.21.18
+          image: valory/open-autonomy-user:0.21.20
           options: -v ${{ github.workspace }}:/work
           run: |
             echo "Setting Tag Images"


### PR DESCRIPTION
## Summary

- Wave-2 PR #67 bumped pyproject + agent YAMLs to **OA 0.21.20 / OAEA 2.2.3** but `release.yaml` was missed and still hardcoded `0.21.18`.
- The breaking ref is `-e open-autonomy==0.21.18` passed to `autonomy build-image` (×2, amd64 + arm). It's `EXTRA_DEPENDENCIES` — pip is forced to install old OA inside the agent container alongside the agent's bundled `open-aea-cli-ipfs==2.2.3` / `open-aea-ledger-cosmos==2.2.3`. OA 0.21.18 pins OAEA 2.2.1, so the Docker publish job would fail with `ResolutionImpossible`.
- 6× runner-image refs (`valory/open-autonomy-user:0.21.18`) bumped for consistency too — those weren't strictly broken since the runner only hosts the `autonomy` CLI, but stale.
- Preventive: same break already hit trader v0.35.5 (https://github.com/valory-xyz/trader/actions/runs/25503746701, fixed in valory-xyz/trader#945). Patching here before the next meme-ooorr release tag.

## Test plan

- [ ] CI green on this PR
- [ ] After merge, next release tag confirms Publish Docker Images (amd64 + arm64) succeed end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)