### PR TITLE
chore: bump genai + funds_manager + kv_store hashes

### DIFF
--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifngitemoxhahloctciywjzfmlhp373ijuvrocmwbyxl3bate2fne
 fingerprint_ignore_patterns: []
-agent: valory/memeooorr:0.1.0:bafybeifibpjxicfxyhuwfleivtglqas3p3eavscklyynkmmr7x5dktrzta
+agent: valory/memeooorr:0.1.0:bafybeig5fhmteeqb6stobcdptglinsj4wxa7e65ws2cpuendlm3no2ru44
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -4,12 +4,12 @@
         "connection/valory/twikit/0.1.0": "bafybeidruneqzx5hyr6w2rs2fyyflhiqt2ituuyouxr3x5zl3forzjbqn4",
         "connection/valory/mirror_db/0.1.0": "bafybeifpnteogn6omfoqpjza3e43slyucck247ti6aufqqj4n22z4yt4bm",
         "connection/valory/tweepy/0.1.0": "bafybeihaz3cx7sypsrpqescha3hg35jlr7jylczwfgjoivl5jayjhnjuwe",
-        "skill/valory/memeooorr_abci/0.1.0": "bafybeigiqvdusdd2rbaitoqpngkfft5u5dczworhltft4u3ydlogmovrkq",
-        "skill/valory/memeooorr_chained_abci/0.1.0": "bafybeia5f44kesctss5mxs4wsiredcbosuqgjplmnnfz5bqztw6zovjply",
+        "skill/valory/memeooorr_abci/0.1.0": "bafybeicc4ja3d3bfc64cxjmwfthribng43522ot5onw3s24pbdunaxm2ey",
+        "skill/valory/memeooorr_chained_abci/0.1.0": "bafybeicem7u7ezzezta47na6pbiyclypth5odu55ddewrhsrp7jtbpwq34",
         "skill/valory/agent_db_abci/0.1.0": "bafybeihnufzl2cj6qcg3ifea4jpkukgqxqgonbz6bwu2ou6hi3bxfnhkvm",
-        "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeigewoik6zcmzfsitr42m2vovtp4gu2jgyhz2y5k76uqa3ci7od4ou",
-        "agent/valory/memeooorr/0.1.0": "bafybeifibpjxicfxyhuwfleivtglqas3p3eavscklyynkmmr7x5dktrzta",
-        "service/dvilela/memeooorr/0.1.0": "bafybeid3c6w2xybipfrtossjori6cchcxyvfvukr2jquxlla57qev737ty"
+        "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeigvhu5u3ccwzcylopzowazkcaalctngpcexf7zk3re736ksguhfgm",
+        "agent/valory/memeooorr/0.1.0": "bafybeig5fhmteeqb6stobcdptglinsj4wxa7e65ws2cpuendlm3no2ru44",
+        "service/dvilela/memeooorr/0.1.0": "bafybeiezkk2jklpy5psezmd25ochforv4giqe2nqn34rb73xf6xpuyuec4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -47,13 +47,13 @@
         "contract/valory/subscription_provider/0.1.0": "bafybeid5hvuugwsugq5verujlgfjw2lzchhnucjjnxhjzm4tpdbqht7etm",
         "connection/valory/http_client/0.23.0": "bafybeihel6sg2yayxu7lqygaswdgciaxpqrgsbl5rwx74c6znu5qz2edd4",
         "connection/valory/p2p_libp2p_client/0.1.0": "bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu",
-        "connection/valory/x402/0.1.0": "bafybeiae7y5sdfkdtmrdl4tcgniinpul4tie6rsde6to3y3lxdkorhgac4",
+        "connection/valory/x402/0.1.0": "bafybeicqjg3d6pnlcsu4442qt5tmsjqkqdtc3ulvbjgoh53jyr7z3lbqqi",
         "connection/valory/ledger/0.19.0": "bafybeia7ug4lrctgfwbq7dozqf5nvjqonot7uhtnlhdjidx5qipgy5743m",
         "connection/valory/http_server/0.22.0": "bafybeihs6dufyaa5l4uorplzx3wiyna5qlq2x43tmyl3yonkl265vspdle",
         "connection/valory/abci/0.1.0": "bafybeibcpvyteijct4rz3zl63sn5zwuiwtn6gt6guvr5gufko4332ybgcu",
         "connection/valory/ipfs/0.1.0": "bafybeift7qz5t4ranrpdcbbojwlmh5mxktr6tjrgivc7xsuqswxqa2wp5y",
-        "connection/valory/genai/0.1.0": "bafybeib6kgixol4yax3azkj3lji5zdsymxgc5ecyhgkbbgy3srirvqleiu",
-        "connection/valory/kv_store/0.1.0": "bafybeiepbu6pjw4cduj7tvz6gin7z5yebnpnp2csu75ooi7cvt3erlvsaq",
+        "connection/valory/genai/0.1.0": "bafybeighrq424xlroekehgk2oaqxkvziq22gffqzodm4ynhjgzhch4pcq4",
+        "connection/valory/kv_store/0.1.0": "bafybeiallj66uerng45tk3y75qdkfakzmudmzl7y737ekwzsehisvuinaq",
         "skill/valory/abstract_abci/0.1.0": "bafybeib5qjkpfsxjcur4asube6kctmy2xsrg2hzcele2tmvsstula4lt54",
         "skill/valory/abstract_round_abci/0.1.0": "bafybeidpod4inivvvgzenx46whshq4mzmxgwsxinv6ibdvyemkstam2yz4",
         "skill/valory/transaction_settlement_abci/0.1.0": "bafybeigiojqgbi54jhree3sqrzaudbmjxb7y2ete74bbliryi3t7ztwi5q",
@@ -61,6 +61,6 @@
         "skill/valory/reset_pause_abci/0.1.0": "bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa",
         "skill/valory/termination_abci/0.1.0": "bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu",
         "skill/valory/mech_interact_abci/0.1.0": "bafybeiburftv5nj5427qyue2f5sx56fpfskalnplwoow2ixqbvgio3kfky",
-        "skill/valory/funds_manager/0.1.0": "bafybeihuwnkgrhqixl4zj55fz2awptmpmdnmub2uzkgbx7rve7bnhkkl5i"
+        "skill/valory/funds_manager/0.1.0": "bafybeifff3amddh44muocd4nfo3txu5lltgjtycvqa4jiwgde6idwvdoii"
     }
 }

--- a/packages/valory/agents/memeooorr/aea-config.yaml
+++ b/packages/valory/agents/memeooorr/aea-config.yaml
@@ -14,10 +14,10 @@ connections:
 - valory/ledger:0.19.0:bafybeia7ug4lrctgfwbq7dozqf5nvjqonot7uhtnlhdjidx5qipgy5743m
 - valory/p2p_libp2p_client:0.1.0:bafybeielj3jso3wvrarp5n5rq7llpw4vgxybqiyensgjalb5ubfiawwhhu
 - valory/tweepy:0.1.0:bafybeihaz3cx7sypsrpqescha3hg35jlr7jylczwfgjoivl5jayjhnjuwe
-- valory/kv_store:0.1.0:bafybeiepbu6pjw4cduj7tvz6gin7z5yebnpnp2csu75ooi7cvt3erlvsaq
+- valory/kv_store:0.1.0:bafybeiallj66uerng45tk3y75qdkfakzmudmzl7y737ekwzsehisvuinaq
 - valory/http_server:0.22.0:bafybeihs6dufyaa5l4uorplzx3wiyna5qlq2x43tmyl3yonkl265vspdle
-- valory/genai:0.1.0:bafybeib6kgixol4yax3azkj3lji5zdsymxgc5ecyhgkbbgy3srirvqleiu
-- valory/x402:0.1.0:bafybeiae7y5sdfkdtmrdl4tcgniinpul4tie6rsde6to3y3lxdkorhgac4
+- valory/genai:0.1.0:bafybeighrq424xlroekehgk2oaqxkvziq22gffqzodm4ynhjgzhch4pcq4
+- valory/x402:0.1.0:bafybeicqjg3d6pnlcsu4442qt5tmsjqkqdtc3ulvbjgoh53jyr7z3lbqqi
 contracts:
 - valory/gnosis_safe:0.1.0:bafybeihfmmoyk7tfh6xg5ylqnxpsxqgzgwklablc3zonp55sz6b2vzuzue
 - valory/gnosis_safe_proxy_factory:0.1.0:bafybeicutxdhfofyqt3l2y4udiqgfh22n3sn6fl2i5r7txd2kctvuig4e4
@@ -43,12 +43,12 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeigiojqgbi54jhree3sqrzaudbmjxb7y2ete74bbliryi3t7ztwi5q
 - valory/registration_abci:0.1.0:bafybeietlh4pq5wjsb6srpsqehcq3gwsod5c6gs4jdiwpzkgrwyxhbbbvq
 - valory/reset_pause_abci:0.1.0:bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa
-- valory/memeooorr_abci:0.1.0:bafybeigiqvdusdd2rbaitoqpngkfft5u5dczworhltft4u3ydlogmovrkq
-- valory/memeooorr_chained_abci:0.1.0:bafybeia5f44kesctss5mxs4wsiredcbosuqgjplmnnfz5bqztw6zovjply
+- valory/memeooorr_abci:0.1.0:bafybeicc4ja3d3bfc64cxjmwfthribng43522ot5onw3s24pbdunaxm2ey
+- valory/memeooorr_chained_abci:0.1.0:bafybeicem7u7ezzezta47na6pbiyclypth5odu55ddewrhsrp7jtbpwq34
 - valory/mech_interact_abci:0.1.0:bafybeiburftv5nj5427qyue2f5sx56fpfskalnplwoow2ixqbvgio3kfky
 - valory/agent_db_abci:0.1.0:bafybeihnufzl2cj6qcg3ifea4jpkukgqxqgonbz6bwu2ou6hi3bxfnhkvm
-- valory/agent_performance_summary_abci:0.1.0:bafybeigewoik6zcmzfsitr42m2vovtp4gu2jgyhz2y5k76uqa3ci7od4ou
-- valory/funds_manager:0.1.0:bafybeihuwnkgrhqixl4zj55fz2awptmpmdnmub2uzkgbx7rve7bnhkkl5i
+- valory/agent_performance_summary_abci:0.1.0:bafybeigvhu5u3ccwzcylopzowazkcaalctngpcexf7zk3re736ksguhfgm
+- valory/funds_manager:0.1.0:bafybeifff3amddh44muocd4nfo3txu5lltgjtycvqa4jiwgde6idwvdoii
 default_ledger: ethereum
 required_ledgers:
 - ethereum

--- a/packages/valory/skills/agent_performance_summary_abci/skill.yaml
+++ b/packages/valory/skills/agent_performance_summary_abci/skill.yaml
@@ -24,7 +24,7 @@ fingerprint_ignore_patterns: []
 contracts: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeidpod4inivvvgzenx46whshq4mzmxgwsxinv6ibdvyemkstam2yz4
-- valory/memeooorr_abci:0.1.0:bafybeigiqvdusdd2rbaitoqpngkfft5u5dczworhltft4u3ydlogmovrkq
+- valory/memeooorr_abci:0.1.0:bafybeicc4ja3d3bfc64cxjmwfthribng43522ot5onw3s24pbdunaxm2ey
 handlers:
   abci:
     args: {}

--- a/packages/valory/skills/memeooorr_abci/skill.yaml
+++ b/packages/valory/skills/memeooorr_abci/skill.yaml
@@ -45,9 +45,9 @@ fingerprint:
   tests/test_rounds_info.py: bafybeig7ctx7xngtlhdmvfyrvmddsz74py6g6recmesrshw6dgibgi32zy
 fingerprint_ignore_patterns: []
 connections:
-- valory/kv_store:0.1.0:bafybeiepbu6pjw4cduj7tvz6gin7z5yebnpnp2csu75ooi7cvt3erlvsaq
+- valory/kv_store:0.1.0:bafybeiallj66uerng45tk3y75qdkfakzmudmzl7y737ekwzsehisvuinaq
 - valory/tweepy:0.1.0:bafybeihaz3cx7sypsrpqescha3hg35jlr7jylczwfgjoivl5jayjhnjuwe
-- valory/genai:0.1.0:bafybeib6kgixol4yax3azkj3lji5zdsymxgc5ecyhgkbbgy3srirvqleiu
+- valory/genai:0.1.0:bafybeighrq424xlroekehgk2oaqxkvziq22gffqzodm4ynhjgzhch4pcq4
 - valory/http_server:0.22.0:bafybeihs6dufyaa5l4uorplzx3wiyna5qlq2x43tmyl3yonkl265vspdle
 contracts:
 - valory/gnosis_safe:0.1.0:bafybeihfmmoyk7tfh6xg5ylqnxpsxqgzgwklablc3zonp55sz6b2vzuzue
@@ -66,7 +66,7 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeigiojqgbi54jhree3sqrzaudbmjxb7y2ete74bbliryi3t7ztwi5q
 - valory/mech_interact_abci:0.1.0:bafybeiburftv5nj5427qyue2f5sx56fpfskalnplwoow2ixqbvgio3kfky
 - valory/agent_db_abci:0.1.0:bafybeihnufzl2cj6qcg3ifea4jpkukgqxqgonbz6bwu2ou6hi3bxfnhkvm
-- valory/funds_manager:0.1.0:bafybeihuwnkgrhqixl4zj55fz2awptmpmdnmub2uzkgbx7rve7bnhkkl5i
+- valory/funds_manager:0.1.0:bafybeifff3amddh44muocd4nfo3txu5lltgjtycvqa4jiwgde6idwvdoii
 behaviours:
   main:
     args: {}

--- a/packages/valory/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/valory/skills/memeooorr_chained_abci/skill.yaml
@@ -27,9 +27,9 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeifdzwzz5byan3ytsi46n4n2svtqme6475hk5z77sopymyzqszcpoa
 - valory/transaction_settlement_abci:0.1.0:bafybeigiojqgbi54jhree3sqrzaudbmjxb7y2ete74bbliryi3t7ztwi5q
 - valory/termination_abci:0.1.0:bafybeiadbtzcvzkwbrosshlsubilj7mwzdqfni6dr75wsd3vawhslpwqeu
-- valory/memeooorr_abci:0.1.0:bafybeigiqvdusdd2rbaitoqpngkfft5u5dczworhltft4u3ydlogmovrkq
+- valory/memeooorr_abci:0.1.0:bafybeicc4ja3d3bfc64cxjmwfthribng43522ot5onw3s24pbdunaxm2ey
 - valory/mech_interact_abci:0.1.0:bafybeiburftv5nj5427qyue2f5sx56fpfskalnplwoow2ixqbvgio3kfky
-- valory/agent_performance_summary_abci:0.1.0:bafybeigewoik6zcmzfsitr42m2vovtp4gu2jgyhz2y5k76uqa3ci7od4ou
+- valory/agent_performance_summary_abci:0.1.0:bafybeigvhu5u3ccwzcylopzowazkcaalctngpcexf7zk3re736ksguhfgm
 behaviours:
   main:
     args: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,9 +59,9 @@ prerelease = "allow"
 packages_paths = "packages/valory"
 upstream_pins = [
     "valory-xyz/mech-interact@v0.30.0",
-    "valory-xyz/genai@v7.1.0",
-    "valory-xyz/kv-store@v0.5.0",
-    "valory-xyz/funds-manager@v3.0.0",
+    "valory-xyz/genai@v7.1.1",
+    "valory-xyz/kv-store@v0.5.1",
+    "valory-xyz/funds-manager@v3.0.1",
 ]
 gitleaks_extra_paths = [
     "packages/valory/skills/memeooorr_abci/agentsfun-ui-build/.*",


### PR DESCRIPTION
## Bumped hashes

| Component | Old | New | Source PR |
|---|---|---|---|
| connection/valory/x402 | bafybeiae7y5sdf… | bafybeicqjg3d6p… | [valory-xyz/genai#32](https://github.com/valory-xyz/genai/pull/32) (v7.1.1) |
| connection/valory/genai | bafybeib6kgix… | bafybeighrq424x… | [valory-xyz/genai#32](https://github.com/valory-xyz/genai/pull/32) (v7.1.1) |
| connection/valory/kv_store | bafybeiepbu6p… | bafybeiallj66u… | [valory-xyz/kv-store#13](https://github.com/valory-xyz/kv-store/pull/13) (v0.5.1) |
| skill/valory/funds_manager | bafybeihuwnk… | bafybeifff3am… | [valory-xyz/funds-manager#39](https://github.com/valory-xyz/funds-manager/pull/39) (v3.0.1) |

\`protocol/valory/srr\` and \`protocol/valory/kv_store\` were already at the target hashes, no diff. \`protocol/valory/llm\` and \`connection/valory/openai\` are not referenced by this repo, so were not added.

\`pyproject.toml\` upstream_pins were also bumped to the new tags so \`check-third-party-hashes\` keeps passing.

## Regression findings

**kv_store v0.5.1 - semantic change.** Pre-bump, the connection returned the full \`Store\` table for any read. Post-bump it filters by the exact requested keys and replies \`ERROR\` on DB exceptions. Audited all 8 in-repo callers of \`_read_kv\`/\`read_kv\`:

- \`behaviour_classes/base.py:263\` wrapper sends \`READ_REQUEST(keys=…)\`, treats any non-\`READ_RESPONSE\` as None, maps via \`{key: response.data.get(key, None) for key in keys}\`. Compatible with both old and new semantics.
- All 8 call sites (\`db.py:101\`, \`db.py:108\`, \`llm.py:292\`, \`chain.py:789\`, \`base.py:375\`, \`base.py:722\`, \`base.py:979\`, \`base.py:995\`) pass concrete keys (no stub-key-then-read-all pattern) and check None/falsy before using the data. No callers needed fixing.

**genai / x402.** New \`PaymentRejectedAfterRetryError\` is a subclass of \`PaymentError\`. The single \`except PaymentError\` in \`connections/genai/connection.py:334\` catches it correctly. No consumer code in this repo catches \`PaymentError\` directly. No substring matches for the old retry-body wording.

**funds_manager.** Single consumer is \`memeooorr_abci/handlers.py\`, which imports \`GET_FUNDS_STATUS_METHOD_NAME\` and \`FundRequirements\` and calls \`.get_response_body()\`. All three are still exported with the same shape.

## Local CI

All workflow checks ran clean against the new packages:

- [x] \`uv lock --check\`
- [x] \`tomte tox -e check-hash\`
- [x] \`tomte tox -e check-packages\`
- [x] \`tomte tox -e check-dependencies\`
- [x] \`tomte tox -e check-third-party-hashes\` (after bumping upstream_pins to v7.1.1 / v0.5.1 / v3.0.1)
- [x] \`tomte tox -e check-doc-hashes\`
- [x] \`tomte tox -e check-abci-docstrings\`
- [x] \`tomte tox -e check-abciapp-specs\`
- [x] \`tomte tox -e check-handlers\`
- [x] \`tomte tox -e gitleaks\`
- [x] \`tomte tox -p -e black-check -e isort-check -e flake8\`
- [x] \`tomte tox -e mypy\`
- [x] \`tomte tox -e pylint\`
- [x] \`tomte tox -e darglint\`
- [x] \`tomte tox -p -e safety -e bandit\`
- [x] \`tomte tox -e py3.12-darwin\` - 1354 passed
- [x] \`autonomy packages lock --check\`
- [x] \`autonomy push-all\`

\`tomte check-copyright\` flags \`packages/valory/protocols/__init__.py\` as malformed (empty file), but that's a pre-existing repo issue (autonomy sync auto-creates that file).

## Local proof - kv_store path

Wrote and ran a four-scenario script against the real \`KvStoreConnection.read_request\` in the new package plus the exact response-handling logic from \`base.py:263-285\`. All four passed:

1. Extra unrelated rows in DB do NOT leak when one key is requested.
2. Missing key in DB → wrapper returns \`{key: None}\`, consumer falls back to default.
3. DB exception → ERROR performative → wrapper returns None → consumer falls back.
4. Multi-key request with mix of present/missing returns exact, requested-keys-only map.

## End-to-end agent boot

Built the agent at the freshly pushed dev-hash (\`bafybeig5fhmteeq...\`) via \`make agent\`, pointed it at a real \`.env\` (Base mainnet RPC, real wallet, x402 + Gemini, etc.) and ran it for ~3 minutes. The FSM traversed 17 distinct rounds including \`mech_request_round\`, \`finalization_round\`, and \`validate_transaction_round\` - i.e. a full production cycle, not just startup.

Observed on the bumped surfaces, zero errors:

- **kv_store v0.5.1** - 18 \`DB read:\` and 36 \`DB write:\` events from the new connection, all responding \`success\`. Round-trip confirmed: skill logs \`Reading keys from db: ('persona', 'initial_persona')\` then connection logs \`DB read: 2 keys\` then the loaded values are used by \`load_database_behaviour\`. Mix of 1-key and 2-key reads exercises the new filtering semantic in production.
- **genai + x402 v7.1.1** - 2 paid Gemini calls via \`https://x402.olas.autonolas.tech/.../gemini-2.5-flash:generateContent\`, both returned valid structured JSON (\`{\"tool_action\": ..., \"tweet_action\": ...}\`). 16 USDC balance checks succeeded. 0 PaymentErrors.
- **funds_manager v3.0.1** - \`/funds-status\` HTTP endpoint hit 8 times via \`_handle_get_funds_status\`, every call returned HTTP 200 with the new \`FundRequirements\` shape (\`{chain: {address: {token: {balance, deficit, decimals}}}}\`) populated with real on-chain balances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)