### PR TITLE
chore(ci): add Snyk security scanning workflow

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -1,0 +1,47 @@
+name: Snyk Security
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  snyk:
+    continue-on-error: True
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    runs-on: ubuntu-24.04
+
+    env:
+      SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+
+    steps:
+      - uses: actions/checkout@v6
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Export requirements for Snyk
+        run: uv export --format requirements-txt --no-hashes --no-editable --no-emit-project > requirements.txt
+      - name: Set up Snyk CLI to check for security issues
+        uses: snyk/actions/setup@806182742461562b67788a64410098c9d9b96adb
+
+      - name: Snyk Code test
+        run: snyk code test --sarif > snyk-code.sarif
+        continue-on-error: true
+
+      - name: Snyk Open Source monitor
+        run: snyk monitor --file=requirements.txt --package-manager=pip --skip-unresolved
+
+      - name: Upload result to GitHub Code Scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: snyk-code.sarif


### PR DESCRIPTION
## Summary
- Add a `Snyk Security` workflow at `.github/workflows/snyk-security.yml`.
- Runs on every PR and push to `main`. Performs Snyk Code (SAST) and Snyk Open Source (SCA) scans and uploads SAST results to GitHub Code Scanning.

## Why
- Brings this repo in line with the other Pearl-bundled agents (`optimus`, `trader`) and the rest of the Snyk-covered repos in the org (`olas-operate-app`, `olas-operate-middleware`, `open-aea`, `open-autonomy`, `autonolas-frontend-mono`). Closes a coverage gap surfaced in the latest secrets audit.

## Pre-merge requirement (handled by repo owner)
- A repo-level `SNYK_TOKEN` Secret must be set before merge, otherwise the Snyk steps will run with empty credentials.

## Test plan
- [ ] Once `SNYK_TOKEN` is set, the Snyk Security workflow runs successfully on the next PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
