### PR TITLE
feat(config): restore + extend named env vars in aea-config.yaml

### DIFF
--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifngitemoxhahloctciywjzfmlhp373ijuvrocmwbyxl3bate2fne
 fingerprint_ignore_patterns: []
-agent: valory/memeooorr:0.1.0:bafybeib5krdk66trldkjkmmwkvrduapivrdf7nuo3coiiqhzqva3ecn6oq
+agent: valory/memeooorr:0.1.0:bafybeicwew2ueta2suyxsmiipe3ltfgfj6jaerlqksbdmf4xjpvheazavu
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -8,8 +8,8 @@
         "skill/valory/memeooorr_chained_abci/0.1.0": "bafybeibwhs4bp7drrwanjexfqvgo23jfa34d7iestzqmipuatlvmsowoxa",
         "skill/valory/agent_db_abci/0.1.0": "bafybeihzfvyn7zskif4wfyy7cgw5uxra6ktjvikuq3gmes6sj2gmkfbani",
         "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeiglxqwyr5idglsores4xjxehcnjtwzcxvr2wzla6f5wzzgnrbuivq",
-        "agent/valory/memeooorr/0.1.0": "bafybeib5krdk66trldkjkmmwkvrduapivrdf7nuo3coiiqhzqva3ecn6oq",
-        "service/dvilela/memeooorr/0.1.0": "bafybeifvkpaplevlghhjsxitpra7h6pauudvlvlx3snsakjvl3rkvd6csq"
+        "agent/valory/memeooorr/0.1.0": "bafybeicwew2ueta2suyxsmiipe3ltfgfj6jaerlqksbdmf4xjpvheazavu",
+        "service/dvilela/memeooorr/0.1.0": "bafybeido37d54qhamw5ismqig3jrjuxn4gxtsaz6spn2iet72iuh4rukb4"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",

--- a/packages/valory/agents/memeooorr/aea-config.yaml
+++ b/packages/valory/agents/memeooorr/aea-config.yaml
@@ -65,10 +65,10 @@ logging_config:
     logfile:
       class: logging.handlers.RotatingFileHandler
       formatter: standard
-      filename: ${str:log.txt}
-      level: ${str:INFO}
-      maxBytes: ${int:52428800}
-      backupCount: ${int:1}
+      filename: ${LOG_FILE:str:log.txt}
+      level: ${LOG_LEVEL:str:INFO}
+      maxBytes: ${LOG_MAX_BYTES:int:52428800}
+      backupCount: ${LOG_BACKUP_COUNT:int:1}
     console:
       class: logging.StreamHandler
       formatter: standard
@@ -90,7 +90,7 @@ default_connection: null
 public_id: valory/kv_store:0.1.0
 type: connection
 config:
-  store_path: ${str:null}
+  store_path: ${STORE_PATH:str:null}
 ---
 public_id: valory/abci:0.1.0
 type: connection
@@ -105,8 +105,8 @@ type: connection
 config:
   ledger_apis:
     base:
-      address: ${str:http://localhost:8545}
-      chain_id: ${int:8453}
+      address: ${BASE_LEDGER_RPC:str:http://localhost:8545}
+      chain_id: ${BASE_LEDGER_CHAIN_ID:int:8453}
       poa_chain: ${bool:false}
       default_gas_price_strategy: ${str:eip1559}
       gas_price_strategies: &id001
@@ -124,8 +124,8 @@ config:
             baseFee: null
           priority_fee_increase_boundary: ${int:200}
     celo:
-      address: ${str:http://localhost:8545}
-      chain_id: ${int:42220}
+      address: ${CELO_LEDGER_RPC:str:http://localhost:8545}
+      chain_id: ${CELO_LEDGER_CHAIN_ID:int:42220}
       poa_chain: ${bool:true}
       default_gas_price_strategy: ${str:eip1559}
       gas_price_strategies: *id001
@@ -151,7 +151,7 @@ type: skill
 models:
   benchmark_tool:
     args:
-      log_dir: ${str:/logs}
+      log_dir: ${LOG_DIR:str:/logs}
   params:
     args:
       cleanup_history_depth: 1
@@ -180,9 +180,9 @@ models:
       multisend_address: ${str:0xA238CBeb142c10Ef7Ad8442C6D1f9E89e07e7761}
       init_fallback_gas: 800000
       keeper_allowed_retries: 3
-      reset_pause_duration: ${int:300}
-      on_chain_service_id: ${int:null}
-      reset_tendermint_after: ${int:2}
+      reset_pause_duration: ${RESET_PAUSE_DURATION:int:300}
+      on_chain_service_id: ${ON_CHAIN_SERVICE_ID:int:null}
+      reset_tendermint_after: ${RESET_TENDERMINT_AFTER:int:2}
       retry_attempts: 400
       retry_timeout: 3
       request_retry_delay: 1.0
@@ -191,8 +191,8 @@ models:
       service_id: memeooorr
       service_registry_address: ${str:0x48b6af7B12C71f09e2fC8aF4855De4Ff54e775cA}
       setup:
-        all_participants: ${list:["0x8426B9F3e3E6d8ec2E83391CE3Db9Dec69570234"]}
-        safe_contract_address: ${str:0x0000000000000000000000000000000000000000}
+        all_participants: ${ALL_PARTICIPANTS:list:["0x8426B9F3e3E6d8ec2E83391CE3Db9Dec69570234"]}
+        safe_contract_address: ${SAFE_CONTRACT_ADDRESS:str:0x0000000000000000000000000000000000000000}
         consensus_threshold: ${int:null}
       share_tm_config_on_startup: ${bool:false}
       sleep_time: 1
@@ -214,30 +214,30 @@ models:
       multisend_batch_size: ${int:50}
       ipfs_address: ${str:https://gateway.autonolas.tech/ipfs/}
       default_chain_id: ${str:base}
-      termination_from_block: ${int:21629820}
-      minimum_gas_balance: ${float:0.00005}
-      min_feedback_replies: ${int:10}
+      termination_from_block: ${TERMINATION_FROM_BLOCK:int:21629820}
+      minimum_gas_balance: ${MINIMUM_GAS_BALANCE:float:0.00005}
+      min_feedback_replies: ${MIN_FEEDBACK_REPLIES:int:10}
       meme_factory_address_base: ${str:0x82a9c823332518c32a0c0edc050ef00934cf04d4}
       meme_factory_address_celo: ${str:0xeea5f1e202dc43607273d54101ff8b58fb008a99}
       meme_factory_deployment_block_base: ${int:23540622}
       meme_factory_deployment_block_celo: ${int:29323752}
       olas_token_address_base: ${str:0x54330d28ca3357F294334BDC454a032e7f353416}
       olas_token_address_celo: ${str:0xaCFfAe8e57Ec6E394Eb1b41939A8CF7892DbDc51}
-      persona: ${str:a cat lover that is crazy about all-things cats.}
-      store_path: ${str:/data}
+      persona: ${PERSONA:str:a cat lover that is crazy about all-things cats.}
+      store_path: ${STORE_PATH:str:/data}
       home_chain_id: ${str:BASE}
       meme_subgraph_url: ${str:https://agentsfun-indexer-production.up.railway.app}
-      skip_engagement: ${bool:false}
+      skip_engagement: ${SKIP_ENGAGEMENT:bool:false}
       min_summon_amount_base: ${float:0.01}
       max_summon_amount_base: ${float:0.02}
       max_heart_amount_base: ${float:0.0002}
       min_summon_amount_celo: ${float:10.0}
       max_summon_amount_celo: ${float:20.0}
       max_heart_amount_celo: ${float:0.2}
-      staking_token_contract_address: ${str:0x0000000000000000000000000000000000000000}
-      activity_checker_contract_address: ${str:0x0000000000000000000000000000000000000000}
-      alternative_model_for_tweets: ${dict:{"use":false,"url":"https://api.fireworks.ai/inference/v1/chat/completions","api_key":null,"model":"accounts/sentientfoundation/models/dobby-unhinged-llama-3-3-70b-new","max_tokens":16384,"top_p":1,"top_k":40,"presence_penalty":0,"frequency_penalty":0,"temperature":0.6}}
-      fireworks_api_key: ${str:null}
+      staking_token_contract_address: ${STAKING_TOKEN_CONTRACT_ADDRESS:str:0x0000000000000000000000000000000000000000}
+      activity_checker_contract_address: ${ACTIVITY_CHECKER_CONTRACT_ADDRESS:str:0x0000000000000000000000000000000000000000}
+      alternative_model_for_tweets: ${ALTERNATIVE_MODEL_FOR_TWEETS:dict:{"use":false,"url":"https://api.fireworks.ai/inference/v1/chat/completions","api_key":null,"model":"accounts/sentientfoundation/models/dobby-unhinged-llama-3-3-70b-new","max_tokens":16384,"top_p":1,"top_k":40,"presence_penalty":0,"frequency_penalty":0,"temperature":0.6}}
+      fireworks_api_key: ${FIREWORKS_API_KEY:str:null}
       tx_loop_breaker_count: 3
       tools_for_mech: ${dict:{}}
       mech_contract_address: '0xe535D7AcDEeD905dddcb5443f41980436833cA2B'
@@ -246,19 +246,19 @@ models:
       use_mech_marketplace: true
       mech_marketplace_config: ${dict:{"mech_marketplace_address":"0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020","priority_mech_address":"0xe535D7AcDEeD905dddcb5443f41980436833cA2B","priority_mech_staking_instance_address":"0x0000000000000000000000000000000000000000","priority_mech_service_id":0,"requester_staking_instance_address":"0x0000000000000000000000000000000000000000","use_dynamic_mech_selection":false,"response_timeout":300}}
       use_acn_for_delivers: false
-      summon_cooldown_seconds: ${int:2592000}
+      summon_cooldown_seconds: ${SUMMON_COOLDOWN_SECONDS:int:2592000}
       heart_cooldown_hours: ${int:48}
-      is_memecoin_logic_enabled: ${bool:false}
-      use_x402: ${bool:false}
-      genai_api_key: ${str:""}
-      x402_payment_requirements: ${dict:{"threshold":200000,"top_up":250000}}
-      base_ledger_rpc: ${str:https://1rpc.io/base}
+      is_memecoin_logic_enabled: ${IS_MEMECOIN_LOGIC_ENABLED:bool:false}
+      use_x402: ${USE_X402:bool:false}
+      genai_api_key: ${GENAI_API_KEY:str:""}
+      x402_payment_requirements: ${X402_PAYMENT_REQUIREMENTS:dict:{"threshold":200000,"top_up":250000}}
+      base_ledger_rpc: ${BASE_LEDGER_RPC:str:https://1rpc.io/base}
       lifi_quote_to_amount_url: ${str:https://li.quest/v1/quote/toAmount}
-      is_agent_performance_summary_enabled: ${bool:true}
-      performance_summary_ttl: ${int:86400}
-      stop_posting_if_staking_kpi_met: ${bool:true}
-      valid_mechs: ${list:["0xe535d7acdeed905dddcb5443f41980436833ca2b"]}
-      valid_tools: ${list:["google_image_gen"]}
+      is_agent_performance_summary_enabled: ${IS_AGENT_PERFORMANCE_SUMMARY_ENABLED:bool:true}
+      performance_summary_ttl: ${PERFORMANCE_SUMMARY_TTL:int:86400}
+      stop_posting_if_staking_kpi_met: ${STOP_POSTING_IF_STAKING_KPI_MET:bool:true}
+      valid_mechs: ${VALID_MECHS:list:["0xe535d7acdeed905dddcb5443f41980436833ca2b"]}
+      valid_tools: ${VALID_TOOLS:list:["google_image_gen"]}
       penalize_mech_time_window: 1800
       mech_wrapped_native_token_address: ${str:0x4200000000000000000000000000000000000006}
       deliveries_lookback_days: ${int:30}
@@ -295,19 +295,19 @@ config:
 public_id: valory/genai:0.1.0:bafybeicblltx7ha3ulthg7bzfccuqqyjmihhrvfeztlgrlcoxhr7kf6nbq
 type: connection
 config:
-  genai_api_key: ${str:null}
-  genai_x402_server_base_url: ${str:https://x402.olas.autonolas.tech/v1/gemini/base/v1beta}
-  use_x402: ${bool:false}
+  genai_api_key: ${GENAI_API_KEY:str:null}
+  genai_x402_server_base_url: ${GENAI_X402_SERVER_BASE_URL:str:https://x402.olas.autonolas.tech/v1/gemini/base/v1beta}
+  use_x402: ${USE_X402:bool:false}
 ---
 public_id: valory/tweepy:0.1.0:bafybeicblltx7ha3ulthg7bzfccuqqyjmihhrvfeztlgrlcoxhr7kf6nbq
 type: connection
 config:
-  tweepy_consumer_api_key: ${str:null}
-  tweepy_consumer_api_key_secret: ${str:null}
-  tweepy_bearer_token: ${str:null}
-  tweepy_access_token: ${str:null}
-  tweepy_access_token_secret: ${str:null}
-  tweepy_skip_auth: ${bool:false}
+  tweepy_consumer_api_key: ${TWEEPY_CONSUMER_API_KEY:str:null}
+  tweepy_consumer_api_key_secret: ${TWEEPY_CONSUMER_API_KEY_SECRET:str:null}
+  tweepy_bearer_token: ${TWEEPY_BEARER_TOKEN:str:null}
+  tweepy_access_token: ${TWEEPY_ACCESS_TOKEN:str:null}
+  tweepy_access_token_secret: ${TWEEPY_ACCESS_TOKEN_SECRET:str:null}
+  tweepy_skip_auth: ${TWEEPY_SKIP_AUTH:bool:false}
 ---
 public_id: valory/agent_db_abci:0.1.0:bafybeicblltx7ha3ulthg7bzfccuqqyjmihhrvfeztlgrlcoxhr7kf6nbq
 type: skill
@@ -323,4 +323,4 @@ models:
     args:
       fund_requirements: ${dict:{"base":{"agent":{"0x0000000000000000000000000000000000000000":{"topup":325700000000000,"threshold":99000000000000}},"safe":{"0x0000000000000000000000000000000000000000":{"topup":1628500000000000,"threshold":99000000000000}}}}}
       rpc_urls: ${dict:{"base":"https://1rpc.io/base"}}
-      safe_contract_addresses: ${dict:{"base":"0x0000000000000000000000000000000000000000"}}
+      safe_contract_addresses: ${SAFE_CONTRACT_ADDRESSES:dict:{"base":"0x0000000000000000000000000000000000000000"}}


### PR DESCRIPTION
## Summary

Re-applies the named `${VAR:type:default}` syntax to `packages/valory/agents/memeooorr/aea-config.yaml`, **plus** names new operator-tunable parameters added since the original work.

The original named-env-var work (commit `d6ec8d0c`) was reverted in `7ca3f4ba` because open-autonomy and the middleware lacked support at the time; both have since shipped that support. `service.yaml` was already restored to named form via `f6abe11a` — only the agent-level defaults were still anonymous.

**Restored (originally named, then reverted):** 44 vars — LOG_*, STORE_PATH, BASE_LEDGER_RPC, CELO_LEDGER_RPC, ALL_PARTICIPANTS, SAFE_CONTRACT_ADDRESS, RESET_TENDERMINT_AFTER, RESET_PAUSE_DURATION, ON_CHAIN_SERVICE_ID, etc.

**Newly named (added to agent after the original PR):**
- `VALID_MECHS`
- `VALID_TOOLS`

**Intentionally left anonymous:** framework/protocol internals (Tendermint timeouts, consensus settings, HTTP method strings, fixed protocol addresses).

Hashes re-locked via `autonomy packages lock`.

## Test plan

- [x] `tomte tox -e check-hash`, `check-packages`
- [x] `tomte tox -e check-abciapp-specs`, `check-handlers`, `check-abci-docstrings`
- [x] `tomte tox -e check-dependencies`, `check-third-party-hashes`, `check-doc-hashes`
- [x] `tomte tox -p -e black-check -e isort-check -e flake8 -e mypy -e darglint`, `pylint`
- [x] `tomte tox -e py3.11-darwin` — all passed
- [ ] Smoke-test agent run to confirm middleware resolves the named vars

🤖 Generated with [Claude Code](https://claude.com/claude-code)