### PR TITLE
fix: check-agent-runner overrides via named env var STORE_PATH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,9 +215,10 @@ build-agent-runner-mac: uv-install  agent
 
 .PHONY: check-agent-runner
 check-agent-runner:
-	# aea-config.yaml uses anonymous templates (${str:/data}) so Pearl's
-	# path-based env-var injection wins at runtime; a named template would
-	# suppress the fallback. See valory-xyz/olas-operate-middleware#424.
+	# aea-config.yaml uses named templates (${STORE_PATH:str:null}) for both
+	# the kv_store connection and memeooorr_chained_abci skill params, so a
+	# single STORE_PATH override drives both. Path-based env vars like
+	# CONNECTION_..._STORE_PATH / SKILL_..._STORE_PATH are silently ignored
+	# when the template has an explicit var name.
 	uv run aea-helpers check-binary ./dist/agent_runner_bin$(EXE_SUFFIX) ./agent \
-	--env-var CONNECTION_KV_STORE_CONFIG_STORE_PATH=$(STORE_PATH_VALUE) \
-	--env-var SKILL_MEMEOOORR_CHAINED_ABCI_MODELS_PARAMS_ARGS_STORE_PATH=$(STORE_PATH_VALUE)
+	--env-var STORE_PATH=$(STORE_PATH_VALUE)


### PR DESCRIPTION
## Summary

The release workflow's `check-agent-runner` smoke test crashes during binary boot with `TypeError: Path(None)` inside `KvStoreConnection.__init__`. Forward-fix for the regression introduced by a81d3fc9.

a81d3fc9 switched the Makefile to path-based env vars (`CONNECTION_KV_STORE_CONFIG_STORE_PATH`, `SKILL_..._STORE_PATH`) because at the time `aea-config.yaml` used anonymous templates (`${str:/data}`) that only resolve via path-keyed injection. PR #88 (`feat/restore-named-env-vars`) then restored named templates (`${STORE_PATH:str:null}`) in `aea-config.yaml`, which makes path-based injection a silent no-op — the kv_store connection sees `store_path: null` and `Path(None)` raises.

The fix replaces the two path-based `--env-var` lines with a single `--env-var STORE_PATH=$(STORE_PATH_VALUE)` that drives both the kv_store connection and the memeooorr_chained_abci skill (they share the same `${STORE_PATH:...}` placeholder). Also refreshes the inline comment, which still claimed the templates were anonymous.

Same regression and same fix shape as the equivalent change being applied to optimus.

## Test plan

- [ ] Re-run the failing release workflow on this branch and confirm `check-agent-runner` passes
- [x] Local: agent boots past `KvStoreConnection.__init__` and reaches the FSM (`registration_startup_round`) when `STORE_PATH` is the only store-path-related env var set

🤖 Generated with [Claude Code](https://claude.com/claude-code)