### PR TITLE
ci(snyk): tag CLI scans with public repo URL so they use the open-source quota

### DIFF
--- a/.github/workflows/snyk-security.yml
+++ b/.github/workflows/snyk-security.yml
@@ -35,11 +35,11 @@ jobs:
         uses: snyk/actions/setup@806182742461562b67788a64410098c9d9b96adb
 
       - name: Snyk Code test
-        run: snyk code test --sarif > snyk-code.sarif
+        run: snyk code test --remote-repo-url=https://github.com/${{ github.repository }} --sarif > snyk-code.sarif
         continue-on-error: true
 
       - name: Snyk Open Source monitor
-        run: snyk monitor --file=requirements.txt --package-manager=pip --skip-unresolved
+        run: snyk monitor --file=requirements.txt --package-manager=pip --skip-unresolved --remote-repo-url=https://github.com/${{ github.repository }}
 
       - name: Upload result to GitHub Code Scanning
         uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
## What

Add `--remote-repo-url=https://github.com/${{ github.repository }}` to both the `snyk code test` and `snyk monitor` commands in `.github/workflows/snyk-security.yml`.

## Why

Snyk CLI scans without `--remote-repo-url` can't read the repository's GitHub visibility, so they **default to counting against the private test quota** — even though this repo is public. On the Snyk Free plan that burns the limited private-manifest and Snyk Code allowances instead of the **unlimited open-source** buckets these public-repo scans are entitled to.

Passing the repo URL tells the CLI which public repo it's scanning, so future runs are classified as open-source and stop consuming quota. `${{ github.repository }}` resolves to `owner/repo` automatically.

The flag is supported by both `snyk code test` and `snyk monitor` per the [Snyk CLI docs](https://docs.snyk.io/developer-tools/snyk-cli/snyk-cli/commands/code-test); no behavioural change beyond classification.

Part of an org-wide fix across all repos running the shared `snyk-security.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)