### PR TITLE
chore: bump mech-interact to v0.32.5

### DIFF
--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifngitemoxhahloctciywjzfmlhp373ijuvrocmwbyxl3bate2fne
 fingerprint_ignore_patterns: []
-agent: valory/memeooorr:0.1.0:bafybeifi2ofrpqgoikv6pgm3n2l6ecfj72xjstj2lokx7sqfmdaccdz56q
+agent: valory/memeooorr:0.1.0:bafybeiglmz4xcg2qtggha2rec45xabl2odnukxysuvy5zxadunyr2utgqu
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -4,12 +4,12 @@
         "connection/valory/twikit/0.1.0": "bafybeidruneqzx5hyr6w2rs2fyyflhiqt2ituuyouxr3x5zl3forzjbqn4",
         "connection/valory/mirror_db/0.1.0": "bafybeifpnteogn6omfoqpjza3e43slyucck247ti6aufqqj4n22z4yt4bm",
         "connection/valory/tweepy/0.1.0": "bafybeihaz3cx7sypsrpqescha3hg35jlr7jylczwfgjoivl5jayjhnjuwe",
-        "skill/valory/memeooorr_abci/0.1.0": "bafybeigjihs6fb46k6shul7icvieccnya3jdo7bgd6j7p25ox23qkwkyki",
-        "skill/valory/memeooorr_chained_abci/0.1.0": "bafybeicvxfndfkrxdmdqswwzjuxv3sn6ureiyw5n6tj7xr6ayq3yygurbe",
+        "skill/valory/memeooorr_abci/0.1.0": "bafybeie2th5jszdzxazbm5l7lt3qr7z7n5wymvjdzpz6mvbv3sf4jgrblm",
+        "skill/valory/memeooorr_chained_abci/0.1.0": "bafybeie7rvgla4gag6xt2nmjveaqoo552c4ag4hmbkbgglnwjnioa3k6ee",
         "skill/valory/agent_db_abci/0.1.0": "bafybeiagtellrrf6wkookqk6jjx3wgxts462u6xtifl7gojtulgwitejnu",
-        "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeiczk5y3nupgya2p7jkbo54mpbza6zj27pzl4l4pkf3nfiizmvja6a",
-        "agent/valory/memeooorr/0.1.0": "bafybeifi2ofrpqgoikv6pgm3n2l6ecfj72xjstj2lokx7sqfmdaccdz56q",
-        "service/dvilela/memeooorr/0.1.0": "bafybeiem3zv4rfwd2kld7jcvfn4j7ccrjt5q7bp6tvc2jrwone4en2g7ym"
+        "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeicwz2ewixmb3cjtnibfbjrcqgp7w556zx2defzkpcelvyojjvxgci",
+        "agent/valory/memeooorr/0.1.0": "bafybeiglmz4xcg2qtggha2rec45xabl2odnukxysuvy5zxadunyr2utgqu",
+        "service/dvilela/memeooorr/0.1.0": "bafybeifar6hfr522eq3ujzgfz6dgd2qkyivsj6x2jqypx6qo3yq7xvtjsa"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -63,7 +63,7 @@
         "skill/valory/registration_abci/0.1.0": "bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi",
         "skill/valory/reset_pause_abci/0.1.0": "bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi",
         "skill/valory/termination_abci/0.1.0": "bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeici5tsgtlypnyrnp5colj7katnsyjfdzt6js4xdbnpdms4232muje",
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeiakzlukj5326ma2uzgnppigbsjcgu5lk52jdmzy5fmgzpuzhckdha",
         "skill/valory/funds_manager/0.1.0": "bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by"
     }
 }

--- a/packages/valory/agents/memeooorr/aea-config.yaml
+++ b/packages/valory/agents/memeooorr/aea-config.yaml
@@ -46,11 +46,11 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/memeooorr_abci:0.1.0:bafybeigjihs6fb46k6shul7icvieccnya3jdo7bgd6j7p25ox23qkwkyki
-- valory/memeooorr_chained_abci:0.1.0:bafybeicvxfndfkrxdmdqswwzjuxv3sn6ureiyw5n6tj7xr6ayq3yygurbe
-- valory/mech_interact_abci:0.1.0:bafybeici5tsgtlypnyrnp5colj7katnsyjfdzt6js4xdbnpdms4232muje
+- valory/memeooorr_abci:0.1.0:bafybeie2th5jszdzxazbm5l7lt3qr7z7n5wymvjdzpz6mvbv3sf4jgrblm
+- valory/memeooorr_chained_abci:0.1.0:bafybeie7rvgla4gag6xt2nmjveaqoo552c4ag4hmbkbgglnwjnioa3k6ee
+- valory/mech_interact_abci:0.1.0:bafybeiakzlukj5326ma2uzgnppigbsjcgu5lk52jdmzy5fmgzpuzhckdha
 - valory/agent_db_abci:0.1.0:bafybeiagtellrrf6wkookqk6jjx3wgxts462u6xtifl7gojtulgwitejnu
-- valory/agent_performance_summary_abci:0.1.0:bafybeiczk5y3nupgya2p7jkbo54mpbza6zj27pzl4l4pkf3nfiizmvja6a
+- valory/agent_performance_summary_abci:0.1.0:bafybeicwz2ewixmb3cjtnibfbjrcqgp7w556zx2defzkpcelvyojjvxgci
 - valory/funds_manager:0.1.0:bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by
 default_ledger: ethereum
 required_ledgers:

--- a/packages/valory/skills/agent_performance_summary_abci/skill.yaml
+++ b/packages/valory/skills/agent_performance_summary_abci/skill.yaml
@@ -24,7 +24,7 @@ fingerprint_ignore_patterns: []
 contracts: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/memeooorr_abci:0.1.0:bafybeigjihs6fb46k6shul7icvieccnya3jdo7bgd6j7p25ox23qkwkyki
+- valory/memeooorr_abci:0.1.0:bafybeie2th5jszdzxazbm5l7lt3qr7z7n5wymvjdzpz6mvbv3sf4jgrblm
 handlers:
   abci:
     args: {}

--- a/packages/valory/skills/memeooorr_abci/skill.yaml
+++ b/packages/valory/skills/memeooorr_abci/skill.yaml
@@ -64,7 +64,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/mech_interact_abci:0.1.0:bafybeici5tsgtlypnyrnp5colj7katnsyjfdzt6js4xdbnpdms4232muje
+- valory/mech_interact_abci:0.1.0:bafybeiakzlukj5326ma2uzgnppigbsjcgu5lk52jdmzy5fmgzpuzhckdha
 - valory/agent_db_abci:0.1.0:bafybeiagtellrrf6wkookqk6jjx3wgxts462u6xtifl7gojtulgwitejnu
 - valory/funds_manager:0.1.0:bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by
 behaviours:

--- a/packages/valory/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/valory/skills/memeooorr_chained_abci/skill.yaml
@@ -27,9 +27,9 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
-- valory/memeooorr_abci:0.1.0:bafybeigjihs6fb46k6shul7icvieccnya3jdo7bgd6j7p25ox23qkwkyki
-- valory/mech_interact_abci:0.1.0:bafybeici5tsgtlypnyrnp5colj7katnsyjfdzt6js4xdbnpdms4232muje
-- valory/agent_performance_summary_abci:0.1.0:bafybeiczk5y3nupgya2p7jkbo54mpbza6zj27pzl4l4pkf3nfiizmvja6a
+- valory/memeooorr_abci:0.1.0:bafybeie2th5jszdzxazbm5l7lt3qr7z7n5wymvjdzpz6mvbv3sf4jgrblm
+- valory/mech_interact_abci:0.1.0:bafybeiakzlukj5326ma2uzgnppigbsjcgu5lk52jdmzy5fmgzpuzhckdha
+- valory/agent_performance_summary_abci:0.1.0:bafybeicwz2ewixmb3cjtnibfbjrcqgp7w556zx2defzkpcelvyojjvxgci
 behaviours:
   main:
     args: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ override-dependencies = ["cffi<2.1"]
 [tool.tomte]
 packages_paths = "packages/valory"
 upstream_pins = [
-    "valory-xyz/mech-interact@v0.32.4",
+    "valory-xyz/mech-interact@v0.32.5",
     "valory-xyz/genai@v7.2.2",
     "valory-xyz/kv-store@v0.7.1",
     "valory-xyz/funds-manager@v3.1.2",


### PR DESCRIPTION
## Summary

Bumps \`skill/valory/mech_interact_abci/0.1.0\` to \`bafybeiakzlukj5326ma2uzgnppigbsjcgu5lk52jdmzy5fmgzpuzhckdha\` (mech-interact [v0.32.5](https://github.com/valory-xyz/mech-interact/releases/tag/v0.32.5)).

The v0.32.5 release lands the off-chain request/response epic ([mech-interact#103](https://github.com/valory-xyz/mech-interact/pull/103)) plus the follow-up review fixes. Downstream skill / agent / service fingerprints refreshed via \`autonomy packages lock\` and new content published via \`autonomy push-all\`.

## Test plan

- [x] \`autonomy packages sync\` clean against the new hash set
- [x] \`autonomy packages lock\` refreshed downstream hashes
- [x] \`autonomy push-all\` published the new skill / agent / service content to IPFS
- [ ] Full CI green on this rollup