### PR TITLE
chore: bump mech-interact upstream pin to v0.32.6

### DIFF
--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifngitemoxhahloctciywjzfmlhp373ijuvrocmwbyxl3bate2fne
 fingerprint_ignore_patterns: []
-agent: valory/memeooorr:0.1.0:bafybeiglmz4xcg2qtggha2rec45xabl2odnukxysuvy5zxadunyr2utgqu
+agent: valory/memeooorr:0.1.0:bafybeifov47vrwypjboymjgu2bebu3pc3tsrewoarj64rt6tvwjjgruboi
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -4,12 +4,12 @@
         "connection/valory/twikit/0.1.0": "bafybeidruneqzx5hyr6w2rs2fyyflhiqt2ituuyouxr3x5zl3forzjbqn4",
         "connection/valory/mirror_db/0.1.0": "bafybeifpnteogn6omfoqpjza3e43slyucck247ti6aufqqj4n22z4yt4bm",
         "connection/valory/tweepy/0.1.0": "bafybeihaz3cx7sypsrpqescha3hg35jlr7jylczwfgjoivl5jayjhnjuwe",
-        "skill/valory/memeooorr_abci/0.1.0": "bafybeie2th5jszdzxazbm5l7lt3qr7z7n5wymvjdzpz6mvbv3sf4jgrblm",
-        "skill/valory/memeooorr_chained_abci/0.1.0": "bafybeie7rvgla4gag6xt2nmjveaqoo552c4ag4hmbkbgglnwjnioa3k6ee",
+        "skill/valory/memeooorr_abci/0.1.0": "bafybeigiddypa2lmaqcvs2ztqrxwvh56ddvhh3yfor6iocrxjg5ho5lgui",
+        "skill/valory/memeooorr_chained_abci/0.1.0": "bafybeifhel6lchyjhrmkldb6ny3cpszylyddco3x4a7hy5qpl3v3jimd3a",
         "skill/valory/agent_db_abci/0.1.0": "bafybeiagtellrrf6wkookqk6jjx3wgxts462u6xtifl7gojtulgwitejnu",
-        "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeicwz2ewixmb3cjtnibfbjrcqgp7w556zx2defzkpcelvyojjvxgci",
-        "agent/valory/memeooorr/0.1.0": "bafybeiglmz4xcg2qtggha2rec45xabl2odnukxysuvy5zxadunyr2utgqu",
-        "service/dvilela/memeooorr/0.1.0": "bafybeifar6hfr522eq3ujzgfz6dgd2qkyivsj6x2jqypx6qo3yq7xvtjsa"
+        "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeid4c3cr4hd6mbtmdmdg2t3qfsrlbgitinq2wuxu4vvkjjlwtpirve",
+        "agent/valory/memeooorr/0.1.0": "bafybeifov47vrwypjboymjgu2bebu3pc3tsrewoarj64rt6tvwjjgruboi",
+        "service/dvilela/memeooorr/0.1.0": "bafybeihsqwpuppanmy3qhdqqkeqrvgqw7svfpngbdimq7su4py2c6mubvu"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -63,7 +63,7 @@
         "skill/valory/registration_abci/0.1.0": "bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi",
         "skill/valory/reset_pause_abci/0.1.0": "bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi",
         "skill/valory/termination_abci/0.1.0": "bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeiakzlukj5326ma2uzgnppigbsjcgu5lk52jdmzy5fmgzpuzhckdha",
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeifbkpgivxjexlhrptn2iaju7vyzeusevvucsin6tbjwveniykad2q",
         "skill/valory/funds_manager/0.1.0": "bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by"
     }
 }

--- a/packages/valory/agents/memeooorr/aea-config.yaml
+++ b/packages/valory/agents/memeooorr/aea-config.yaml
@@ -46,11 +46,11 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/memeooorr_abci:0.1.0:bafybeie2th5jszdzxazbm5l7lt3qr7z7n5wymvjdzpz6mvbv3sf4jgrblm
-- valory/memeooorr_chained_abci:0.1.0:bafybeie7rvgla4gag6xt2nmjveaqoo552c4ag4hmbkbgglnwjnioa3k6ee
-- valory/mech_interact_abci:0.1.0:bafybeiakzlukj5326ma2uzgnppigbsjcgu5lk52jdmzy5fmgzpuzhckdha
+- valory/memeooorr_abci:0.1.0:bafybeigiddypa2lmaqcvs2ztqrxwvh56ddvhh3yfor6iocrxjg5ho5lgui
+- valory/memeooorr_chained_abci:0.1.0:bafybeifhel6lchyjhrmkldb6ny3cpszylyddco3x4a7hy5qpl3v3jimd3a
+- valory/mech_interact_abci:0.1.0:bafybeifbkpgivxjexlhrptn2iaju7vyzeusevvucsin6tbjwveniykad2q
 - valory/agent_db_abci:0.1.0:bafybeiagtellrrf6wkookqk6jjx3wgxts462u6xtifl7gojtulgwitejnu
-- valory/agent_performance_summary_abci:0.1.0:bafybeicwz2ewixmb3cjtnibfbjrcqgp7w556zx2defzkpcelvyojjvxgci
+- valory/agent_performance_summary_abci:0.1.0:bafybeid4c3cr4hd6mbtmdmdg2t3qfsrlbgitinq2wuxu4vvkjjlwtpirve
 - valory/funds_manager:0.1.0:bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by
 default_ledger: ethereum
 required_ledgers:

--- a/packages/valory/skills/agent_performance_summary_abci/skill.yaml
+++ b/packages/valory/skills/agent_performance_summary_abci/skill.yaml
@@ -24,7 +24,7 @@ fingerprint_ignore_patterns: []
 contracts: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/memeooorr_abci:0.1.0:bafybeie2th5jszdzxazbm5l7lt3qr7z7n5wymvjdzpz6mvbv3sf4jgrblm
+- valory/memeooorr_abci:0.1.0:bafybeigiddypa2lmaqcvs2ztqrxwvh56ddvhh3yfor6iocrxjg5ho5lgui
 handlers:
   abci:
     args: {}

--- a/packages/valory/skills/memeooorr_abci/skill.yaml
+++ b/packages/valory/skills/memeooorr_abci/skill.yaml
@@ -64,7 +64,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/mech_interact_abci:0.1.0:bafybeiakzlukj5326ma2uzgnppigbsjcgu5lk52jdmzy5fmgzpuzhckdha
+- valory/mech_interact_abci:0.1.0:bafybeifbkpgivxjexlhrptn2iaju7vyzeusevvucsin6tbjwveniykad2q
 - valory/agent_db_abci:0.1.0:bafybeiagtellrrf6wkookqk6jjx3wgxts462u6xtifl7gojtulgwitejnu
 - valory/funds_manager:0.1.0:bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by
 behaviours:

--- a/packages/valory/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/valory/skills/memeooorr_chained_abci/skill.yaml
@@ -27,9 +27,9 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
-- valory/memeooorr_abci:0.1.0:bafybeie2th5jszdzxazbm5l7lt3qr7z7n5wymvjdzpz6mvbv3sf4jgrblm
-- valory/mech_interact_abci:0.1.0:bafybeiakzlukj5326ma2uzgnppigbsjcgu5lk52jdmzy5fmgzpuzhckdha
-- valory/agent_performance_summary_abci:0.1.0:bafybeicwz2ewixmb3cjtnibfbjrcqgp7w556zx2defzkpcelvyojjvxgci
+- valory/memeooorr_abci:0.1.0:bafybeigiddypa2lmaqcvs2ztqrxwvh56ddvhh3yfor6iocrxjg5ho5lgui
+- valory/mech_interact_abci:0.1.0:bafybeifbkpgivxjexlhrptn2iaju7vyzeusevvucsin6tbjwveniykad2q
+- valory/agent_performance_summary_abci:0.1.0:bafybeid4c3cr4hd6mbtmdmdg2t3qfsrlbgitinq2wuxu4vvkjjlwtpirve
 behaviours:
   main:
     args: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ override-dependencies = ["cffi<2.1"]
 [tool.tomte]
 packages_paths = "packages/valory"
 upstream_pins = [
-    "valory-xyz/mech-interact@v0.32.5",
+    "valory-xyz/mech-interact@v0.32.6",
     "valory-xyz/genai@v7.2.2",
     "valory-xyz/kv-store@v0.7.1",
     "valory-xyz/funds-manager@v3.1.2",


### PR DESCRIPTION
## Summary

Metadata-only bump of the mech-interact upstream pin from v0.32.5 to v0.32.6.

v0.32.6 = v0.32.5 + a single bug fix (valory-xyz/mech-interact#112) to how the offchain-request-signing skill wraps `request_ids` for `Safe.isValidSignature`. Only the `mech_interact_abci` skill hash changed upstream; all downstream ripple hashes were regenerated via `autonomy packages sync --update-packages` and `autonomy packages lock`.

Release notes: https://github.com/valory-xyz/mech-interact/releases/tag/v0.32.6

Diff:
- `pyproject.toml`: `mech-interact@v0.32.5` -> `@v0.32.6`
- `packages/packages.json`: `mech_interact_abci` third-party hash updated to `bafybeifbkpgivxjexlhrptn2iaju7vyzeusevvucsin6tbjwveniykad2q`
- Downstream ripple: `memeooorr_abci`, `memeooorr_chained_abci`, `agent_performance_summary_abci`, `agent/memeooorr`, `service/memeooorr`, plus the aea-config skill reference for the same

No code changes in this repo.

## Test plan

Local checks run against this branch:
- [x] `autonomy packages lock --check` passes
- [x] `autonomy push-all` succeeded (published new hashes to IPFS)
- [x] `tomte tox -e check-hash` passes
- [x] `tomte tox -e check-packages` passes
- [x] `tomte tox -e check-third-party-hashes` passes (all 53 hashes consistent with 6 upstreams incl. mech-interact@v0.32.6)
- [x] `tomte tox -e check-dependencies` passes
- [x] `tomte tox -e check-doc-hashes` passes
- [x] `tomte tox -e check-abci-docstrings`, `check-abciapp-specs`, `check-handlers` all pass
- [x] `tomte tox -p -e black-check -e isort-check -e flake8 -e mypy -e pylint -e darglint` all pass
- [x] `tomte tox -e bandit` passes
- [x] `tomte tox -e liccheck` passes
- [x] `tomte tox -e gitleaks` passes (no leaks found)
- [ ] `tomte tox -e safety` reports 3 pre-existing `pip` CVEs (reproduces on `origin/main`, not introduced by this bump)