### PR TITLE
chore: bump mech_interact_abci to v0.32.7; hoist use_offchain and offchain_deposit_target_calls

### DIFF
--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifngitemoxhahloctciywjzfmlhp373ijuvrocmwbyxl3bate2fne
 fingerprint_ignore_patterns: []
-agent: valory/memeooorr:0.1.0:bafybeifov47vrwypjboymjgu2bebu3pc3tsrewoarj64rt6tvwjjgruboi
+agent: valory/memeooorr:0.1.0:bafybeiesa6eby3z32v2i3hlziekedreqagmsr2zd7mclzamwc7pcfnhbpi
 number_of_agents: 1
 deployment:
   agent:
@@ -105,7 +105,9 @@ extra:
         max_summon_amount_celo: ${MAX_SUMMON_AMOUNT_CELO:float:20.0}
         max_heart_amount_celo: ${MAX_HEART_AMOUNT_CELO:float:0.2}
         use_mech_marketplace: ${USE_MECH_MARKETPLACE:bool:true}
-        mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020","priority_mech_address":"0xe535D7AcDEeD905dddcb5443f41980436833cA2B","priority_mech_staking_instance_address":"0x0000000000000000000000000000000000000000","priority_mech_service_id":0,"requester_staking_instance_address":"0x0000000000000000000000000000000000000000","use_dynamic_mech_selection":false,"response_timeout":300,"use_offchain":false,"offchain_url":null,"offchain_deposit_target_calls":10,"auto_deposit_cap_per_cycle":5000000,"offchain_poll_interval_seconds":3.0,"offchain_poll_timeout_seconds":300.0,"offchain_failover_max_retries":2}}
+        mech_marketplace_config: ${MECH_MARKETPLACE_CONFIG:dict:{"mech_marketplace_address":"0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020","priority_mech_address":"0xe535D7AcDEeD905dddcb5443f41980436833cA2B","priority_mech_staking_instance_address":"0x0000000000000000000000000000000000000000","priority_mech_service_id":0,"requester_staking_instance_address":"0x0000000000000000000000000000000000000000","use_dynamic_mech_selection":false,"response_timeout":300,"offchain_url":null,"auto_deposit_cap_per_cycle":5000000,"offchain_poll_interval_seconds":3.0,"offchain_poll_timeout_seconds":300.0,"offchain_failover_max_retries":2}}
+        use_offchain: ${USE_OFFCHAIN:bool:false}
+        offchain_deposit_target_calls: ${OFFCHAIN_DEPOSIT_TARGET_CALLS:int:10}
         mech_contract_address: ${MECH_CONTRACT_ADDRESS:str:0xe535D7AcDEeD905dddcb5443f41980436833cA2B}
         mech_request_price: ${MECH_REQUEST_PRICE:int:100}
         mech_chain_id: ${MECH_CHAIN_ID:str:base}

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -4,12 +4,12 @@
         "connection/valory/twikit/0.1.0": "bafybeidruneqzx5hyr6w2rs2fyyflhiqt2ituuyouxr3x5zl3forzjbqn4",
         "connection/valory/mirror_db/0.1.0": "bafybeifpnteogn6omfoqpjza3e43slyucck247ti6aufqqj4n22z4yt4bm",
         "connection/valory/tweepy/0.1.0": "bafybeihaz3cx7sypsrpqescha3hg35jlr7jylczwfgjoivl5jayjhnjuwe",
-        "skill/valory/memeooorr_abci/0.1.0": "bafybeigiddypa2lmaqcvs2ztqrxwvh56ddvhh3yfor6iocrxjg5ho5lgui",
-        "skill/valory/memeooorr_chained_abci/0.1.0": "bafybeifhel6lchyjhrmkldb6ny3cpszylyddco3x4a7hy5qpl3v3jimd3a",
+        "skill/valory/memeooorr_abci/0.1.0": "bafybeicaq6xx4jfhgsn3yhnmy2po66mur5fhb5hwoguzbgddjaoeygyj7y",
+        "skill/valory/memeooorr_chained_abci/0.1.0": "bafybeicjq3wy5tgi5otv7q7tshyfnrbxlswrzgz2ifekfmt5gvz6uqushq",
         "skill/valory/agent_db_abci/0.1.0": "bafybeiagtellrrf6wkookqk6jjx3wgxts462u6xtifl7gojtulgwitejnu",
-        "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeid4c3cr4hd6mbtmdmdg2t3qfsrlbgitinq2wuxu4vvkjjlwtpirve",
-        "agent/valory/memeooorr/0.1.0": "bafybeifov47vrwypjboymjgu2bebu3pc3tsrewoarj64rt6tvwjjgruboi",
-        "service/dvilela/memeooorr/0.1.0": "bafybeihsqwpuppanmy3qhdqqkeqrvgqw7svfpngbdimq7su4py2c6mubvu"
+        "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeif3kicomdovxotfeg67huyuy5kk4phge6riz6ucodefywueru7tsu",
+        "agent/valory/memeooorr/0.1.0": "bafybeiesa6eby3z32v2i3hlziekedreqagmsr2zd7mclzamwc7pcfnhbpi",
+        "service/dvilela/memeooorr/0.1.0": "bafybeicfw4jzmspcwxp7xizuedcogfw3aqrr4ofu5uqi3ckl3dvgnlufay"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -63,7 +63,7 @@
         "skill/valory/registration_abci/0.1.0": "bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi",
         "skill/valory/reset_pause_abci/0.1.0": "bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi",
         "skill/valory/termination_abci/0.1.0": "bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeifbkpgivxjexlhrptn2iaju7vyzeusevvucsin6tbjwveniykad2q",
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeic5xfxdod5l56o7aojdamojnvi562nql2mlah73bf47d4guz4xnwi",
         "skill/valory/funds_manager/0.1.0": "bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by"
     }
 }

--- a/packages/valory/agents/memeooorr/aea-config.yaml
+++ b/packages/valory/agents/memeooorr/aea-config.yaml
@@ -46,11 +46,11 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/memeooorr_abci:0.1.0:bafybeigiddypa2lmaqcvs2ztqrxwvh56ddvhh3yfor6iocrxjg5ho5lgui
-- valory/memeooorr_chained_abci:0.1.0:bafybeifhel6lchyjhrmkldb6ny3cpszylyddco3x4a7hy5qpl3v3jimd3a
-- valory/mech_interact_abci:0.1.0:bafybeifbkpgivxjexlhrptn2iaju7vyzeusevvucsin6tbjwveniykad2q
+- valory/memeooorr_abci:0.1.0:bafybeicaq6xx4jfhgsn3yhnmy2po66mur5fhb5hwoguzbgddjaoeygyj7y
+- valory/memeooorr_chained_abci:0.1.0:bafybeicjq3wy5tgi5otv7q7tshyfnrbxlswrzgz2ifekfmt5gvz6uqushq
+- valory/mech_interact_abci:0.1.0:bafybeic5xfxdod5l56o7aojdamojnvi562nql2mlah73bf47d4guz4xnwi
 - valory/agent_db_abci:0.1.0:bafybeiagtellrrf6wkookqk6jjx3wgxts462u6xtifl7gojtulgwitejnu
-- valory/agent_performance_summary_abci:0.1.0:bafybeid4c3cr4hd6mbtmdmdg2t3qfsrlbgitinq2wuxu4vvkjjlwtpirve
+- valory/agent_performance_summary_abci:0.1.0:bafybeif3kicomdovxotfeg67huyuy5kk4phge6riz6ucodefywueru7tsu
 - valory/funds_manager:0.1.0:bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by
 default_ledger: ethereum
 required_ledgers:
@@ -247,7 +247,9 @@ models:
       mech_chain_id: base
       mech_interaction_sleep_time: 10
       use_mech_marketplace: true
-      mech_marketplace_config: ${dict:{"mech_marketplace_address":"0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020","priority_mech_address":"0xe535D7AcDEeD905dddcb5443f41980436833cA2B","priority_mech_staking_instance_address":"0x0000000000000000000000000000000000000000","priority_mech_service_id":0,"requester_staking_instance_address":"0x0000000000000000000000000000000000000000","use_dynamic_mech_selection":false,"response_timeout":300,"use_offchain":false,"offchain_url":null,"offchain_deposit_target_calls":10,"auto_deposit_cap_per_cycle":5000000,"offchain_poll_interval_seconds":3.0,"offchain_poll_timeout_seconds":300.0,"offchain_failover_max_retries":2}}
+      mech_marketplace_config: ${dict:{"mech_marketplace_address":"0xf24eE42edA0fc9b33B7D41B06Ee8ccD2Ef7C5020","priority_mech_address":"0xe535D7AcDEeD905dddcb5443f41980436833cA2B","priority_mech_staking_instance_address":"0x0000000000000000000000000000000000000000","priority_mech_service_id":0,"requester_staking_instance_address":"0x0000000000000000000000000000000000000000","use_dynamic_mech_selection":false,"response_timeout":300,"offchain_url":null,"auto_deposit_cap_per_cycle":5000000,"offchain_poll_interval_seconds":3.0,"offchain_poll_timeout_seconds":300.0,"offchain_failover_max_retries":2}}
+      use_offchain: ${USE_OFFCHAIN:bool:false}
+      offchain_deposit_target_calls: ${OFFCHAIN_DEPOSIT_TARGET_CALLS:int:10}
       use_acn_for_delivers: false
       summon_cooldown_seconds: ${SUMMON_COOLDOWN_SECONDS:int:2592000}
       heart_cooldown_hours: ${int:48}

--- a/packages/valory/skills/agent_performance_summary_abci/skill.yaml
+++ b/packages/valory/skills/agent_performance_summary_abci/skill.yaml
@@ -24,7 +24,7 @@ fingerprint_ignore_patterns: []
 contracts: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/memeooorr_abci:0.1.0:bafybeigiddypa2lmaqcvs2ztqrxwvh56ddvhh3yfor6iocrxjg5ho5lgui
+- valory/memeooorr_abci:0.1.0:bafybeicaq6xx4jfhgsn3yhnmy2po66mur5fhb5hwoguzbgddjaoeygyj7y
 handlers:
   abci:
     args: {}

--- a/packages/valory/skills/memeooorr_abci/skill.yaml
+++ b/packages/valory/skills/memeooorr_abci/skill.yaml
@@ -64,7 +64,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/mech_interact_abci:0.1.0:bafybeifbkpgivxjexlhrptn2iaju7vyzeusevvucsin6tbjwveniykad2q
+- valory/mech_interact_abci:0.1.0:bafybeic5xfxdod5l56o7aojdamojnvi562nql2mlah73bf47d4guz4xnwi
 - valory/agent_db_abci:0.1.0:bafybeiagtellrrf6wkookqk6jjx3wgxts462u6xtifl7gojtulgwitejnu
 - valory/funds_manager:0.1.0:bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by
 behaviours:

--- a/packages/valory/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/valory/skills/memeooorr_chained_abci/skill.yaml
@@ -27,9 +27,9 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
-- valory/memeooorr_abci:0.1.0:bafybeigiddypa2lmaqcvs2ztqrxwvh56ddvhh3yfor6iocrxjg5ho5lgui
-- valory/mech_interact_abci:0.1.0:bafybeifbkpgivxjexlhrptn2iaju7vyzeusevvucsin6tbjwveniykad2q
-- valory/agent_performance_summary_abci:0.1.0:bafybeid4c3cr4hd6mbtmdmdg2t3qfsrlbgitinq2wuxu4vvkjjlwtpirve
+- valory/memeooorr_abci:0.1.0:bafybeicaq6xx4jfhgsn3yhnmy2po66mur5fhb5hwoguzbgddjaoeygyj7y
+- valory/mech_interact_abci:0.1.0:bafybeic5xfxdod5l56o7aojdamojnvi562nql2mlah73bf47d4guz4xnwi
+- valory/agent_performance_summary_abci:0.1.0:bafybeif3kicomdovxotfeg67huyuy5kk4phge6riz6ucodefywueru7tsu
 behaviours:
   main:
     args: {}
@@ -186,13 +186,13 @@ models:
         requester_staking_instance_address: '0x0000000000000000000000000000000000000000'
         use_dynamic_mech_selection: false
         response_timeout: 300
-        use_offchain: false
         offchain_url: null
-        offchain_deposit_target_calls: 10
         auto_deposit_cap_per_cycle: 5000000
         offchain_poll_interval_seconds: 3.0
         offchain_poll_timeout_seconds: 300.0
         offchain_failover_max_retries: 2
+      use_offchain: false
+      offchain_deposit_target_calls: 10
       use_acn_for_delivers: false
       valid_mechs: []
       valid_tools: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ override-dependencies = ["cffi<2.1"]
 [tool.tomte]
 packages_paths = "packages/valory"
 upstream_pins = [
-    "valory-xyz/mech-interact@v0.32.6",
+    "valory-xyz/mech-interact@v0.32.7",
     "valory-xyz/genai@v7.2.2",
     "valory-xyz/kv-store@v0.7.1",
     "valory-xyz/funds-manager@v3.1.2",


### PR DESCRIPTION
## Summary

Bumps the `mech_interact_abci` third-party skill pin to v0.32.7 and completes the consumer-side migration of the two hoisted params.

**Upstream references**
- PR: https://github.com/valory-xyz/mech-interact/pull/113
- Release: https://github.com/valory-xyz/mech-interact/releases/tag/v0.32.7

**What v0.32.7 did upstream**
- `use_offchain: bool` moved out of `MechMarketplaceConfig` into a top-level `MechParams.use_offchain` attribute (yaml arg).
- `offchain_deposit_target_calls: int` moved out of `MechMarketplaceConfig` into a top-level `MechParams.offchain_deposit_target_calls` attribute (yaml arg).
- `MechParams.__init__` now raises `ValueError` if the composed `mech_marketplace_config` dict still contains either legacy key, naming the replacement env vars.

## Files changed

- `packages/packages.json` - third_party `mech_interact_abci` bumped to `bafybeic5xfxdod5l56o7aojdamojnvi562nql2mlah73bf47d4guz4xnwi`; dev hashes re-locked for `memeooorr_abci`, `memeooorr_chained_abci`, `agent_performance_summary_abci`, `agent/memeooorr`, `service/memeooorr`.
- `pyproject.toml` - `[tool.tomte].upstream_pins` bumped `valory-xyz/mech-interact@v0.32.6` -> `v0.32.7` (required for `check-third-party-hashes`).
- `packages/valory/agents/memeooorr/aea-config.yaml` - stripped `use_offchain` and `offchain_deposit_target_calls` from the nested `mech_marketplace_config` dict; added top-level `use_offchain: ${USE_OFFCHAIN:bool:false}` and `offchain_deposit_target_calls: ${OFFCHAIN_DEPOSIT_TARGET_CALLS:int:10}` under the `params.args` block; picked up the rippled skill/agent hashes from lock.
- `packages/dvilela/services/memeooorr/service.yaml` - same hoist inside the chained-skill overrides block, using the same env-var placeholders; picked up the rippled agent hash from lock.
- `packages/valory/skills/memeooorr_chained_abci/skill.yaml` - stripped the two keys from the nested block, added top-level `use_offchain: false` and `offchain_deposit_target_calls: 10` (plain values as per the vendored skill convention); picked up rippled skill hashes.
- `packages/valory/skills/memeooorr_abci/skill.yaml` and `packages/valory/skills/agent_performance_summary_abci/skill.yaml` - hash rippling only from `autonomy packages lock`.

No Python consumer in this repo reads `marketplace_config.use_offchain` or `marketplace_config.offchain_deposit_target_calls`, so no Python source edits are needed beyond the vendored skill sync.

## Operator migration (breaking)

If an operator overrides `MECH_MARKETPLACE_CONFIG` via env, the JSON dict MUST drop the two legacy keys:
- Remove `"use_offchain": <bool>` from the dict.
- Remove `"offchain_deposit_target_calls": <int>` from the dict.

And set them as standalone top-level env vars instead:
- `USE_OFFCHAIN=true|false` (default `false`).
- `OFFCHAIN_DEPOSIT_TARGET_CALLS=<int>` (default `10`, must be `>= 1`).

Failing to migrate boots with `ValueError` from `MechParams.__init__` naming the replacement env vars.

## Test plan

- [x] `uv run autonomy packages sync` -> no changes needed (vendored skill already at new hash).
- [x] `uv run autonomy packages lock && uv run autonomy packages lock --check` -> `Verification successful`.
- [x] `uv run tomte tox -e py3.12-darwin` -> 1359 passed.
- [x] `uv run tomte tox -e mypy,black-check,darglint,flake8,isort-check` -> all green.
- [x] `uv run tomte tox -e check-third-party-hashes,check-hash,check-packages` -> all green.
- [x] `uv run tomte tox -e check-abci-docstrings,check-abciapp-specs,check-handlers` -> all green.
- [ ] CI green on this PR.
- [ ] Smoke: boot the service with a stale `MECH_MARKETPLACE_CONFIG` containing either legacy key and confirm the `ValueError` migration guard fires with the replacement-env-var message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)