### PR TITLE
chore(agents-fun): bump mech_interact_abci to v0.32.8

### DIFF
--- a/packages/dvilela/services/memeooorr/service.yaml
+++ b/packages/dvilela/services/memeooorr/service.yaml
@@ -7,7 +7,7 @@ license: Apache-2.0
 fingerprint:
   README.md: bafybeifngitemoxhahloctciywjzfmlhp373ijuvrocmwbyxl3bate2fne
 fingerprint_ignore_patterns: []
-agent: valory/memeooorr:0.1.0:bafybeiesa6eby3z32v2i3hlziekedreqagmsr2zd7mclzamwc7pcfnhbpi
+agent: valory/memeooorr:0.1.0:bafybeifj2zskm7nrgl5u2uyfz22fq3t743mn4w45jahezcwcbwsuvjbmnq
 number_of_agents: 1
 deployment:
   agent:

--- a/packages/packages.json
+++ b/packages/packages.json
@@ -4,12 +4,12 @@
         "connection/valory/twikit/0.1.0": "bafybeidruneqzx5hyr6w2rs2fyyflhiqt2ituuyouxr3x5zl3forzjbqn4",
         "connection/valory/mirror_db/0.1.0": "bafybeifpnteogn6omfoqpjza3e43slyucck247ti6aufqqj4n22z4yt4bm",
         "connection/valory/tweepy/0.1.0": "bafybeihaz3cx7sypsrpqescha3hg35jlr7jylczwfgjoivl5jayjhnjuwe",
-        "skill/valory/memeooorr_abci/0.1.0": "bafybeicaq6xx4jfhgsn3yhnmy2po66mur5fhb5hwoguzbgddjaoeygyj7y",
-        "skill/valory/memeooorr_chained_abci/0.1.0": "bafybeicjq3wy5tgi5otv7q7tshyfnrbxlswrzgz2ifekfmt5gvz6uqushq",
+        "skill/valory/memeooorr_abci/0.1.0": "bafybeiglup4lullo7sucusrm5hv2vvtg7ykcut7to4ajhufli6m7dmkpju",
+        "skill/valory/memeooorr_chained_abci/0.1.0": "bafybeihstbyaa4w2et3ojiuoloa5gw454yoxaz7ffnct6rkzojqiwzwrbu",
         "skill/valory/agent_db_abci/0.1.0": "bafybeiagtellrrf6wkookqk6jjx3wgxts462u6xtifl7gojtulgwitejnu",
-        "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeif3kicomdovxotfeg67huyuy5kk4phge6riz6ucodefywueru7tsu",
-        "agent/valory/memeooorr/0.1.0": "bafybeiesa6eby3z32v2i3hlziekedreqagmsr2zd7mclzamwc7pcfnhbpi",
-        "service/dvilela/memeooorr/0.1.0": "bafybeicfw4jzmspcwxp7xizuedcogfw3aqrr4ofu5uqi3ckl3dvgnlufay"
+        "skill/valory/agent_performance_summary_abci/0.1.0": "bafybeibrbuttmxhunmdjrvibavtjpd7q4kiyezgpbrbvct6trdsuonkok4",
+        "agent/valory/memeooorr/0.1.0": "bafybeifj2zskm7nrgl5u2uyfz22fq3t743mn4w45jahezcwcbwsuvjbmnq",
+        "service/dvilela/memeooorr/0.1.0": "bafybeid3q2yfzezep6y6b7n2ibxkwkebjuj5fr7zftj7ukkqf2q4zaya3a"
     },
     "third_party": {
         "protocol/open_aea/signing/1.0.0": "bafybeifsjmldwyki3beqyvdt5lzenrg6wyrqaar5plc5rpnvtc4zlentye",
@@ -63,7 +63,7 @@
         "skill/valory/registration_abci/0.1.0": "bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi",
         "skill/valory/reset_pause_abci/0.1.0": "bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi",
         "skill/valory/termination_abci/0.1.0": "bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi",
-        "skill/valory/mech_interact_abci/0.1.0": "bafybeic5xfxdod5l56o7aojdamojnvi562nql2mlah73bf47d4guz4xnwi",
+        "skill/valory/mech_interact_abci/0.1.0": "bafybeigv3h4xlkmaahlhhfpp7g6mmspuz7rsudlifhy3kjpvoumrqrioqa",
         "skill/valory/funds_manager/0.1.0": "bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by"
     }
 }

--- a/packages/valory/agents/memeooorr/aea-config.yaml
+++ b/packages/valory/agents/memeooorr/aea-config.yaml
@@ -46,11 +46,11 @@ skills:
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/registration_abci:0.1.0:bafybeif4n2esdjvquomdkwktv7eolepskpo5jlqrfda2abxjqzy2ljsxzi
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
-- valory/memeooorr_abci:0.1.0:bafybeicaq6xx4jfhgsn3yhnmy2po66mur5fhb5hwoguzbgddjaoeygyj7y
-- valory/memeooorr_chained_abci:0.1.0:bafybeicjq3wy5tgi5otv7q7tshyfnrbxlswrzgz2ifekfmt5gvz6uqushq
-- valory/mech_interact_abci:0.1.0:bafybeic5xfxdod5l56o7aojdamojnvi562nql2mlah73bf47d4guz4xnwi
+- valory/memeooorr_abci:0.1.0:bafybeiglup4lullo7sucusrm5hv2vvtg7ykcut7to4ajhufli6m7dmkpju
+- valory/memeooorr_chained_abci:0.1.0:bafybeihstbyaa4w2et3ojiuoloa5gw454yoxaz7ffnct6rkzojqiwzwrbu
+- valory/mech_interact_abci:0.1.0:bafybeigv3h4xlkmaahlhhfpp7g6mmspuz7rsudlifhy3kjpvoumrqrioqa
 - valory/agent_db_abci:0.1.0:bafybeiagtellrrf6wkookqk6jjx3wgxts462u6xtifl7gojtulgwitejnu
-- valory/agent_performance_summary_abci:0.1.0:bafybeif3kicomdovxotfeg67huyuy5kk4phge6riz6ucodefywueru7tsu
+- valory/agent_performance_summary_abci:0.1.0:bafybeibrbuttmxhunmdjrvibavtjpd7q4kiyezgpbrbvct6trdsuonkok4
 - valory/funds_manager:0.1.0:bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by
 default_ledger: ethereum
 required_ledgers:

--- a/packages/valory/skills/agent_performance_summary_abci/skill.yaml
+++ b/packages/valory/skills/agent_performance_summary_abci/skill.yaml
@@ -24,7 +24,7 @@ fingerprint_ignore_patterns: []
 contracts: []
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
-- valory/memeooorr_abci:0.1.0:bafybeicaq6xx4jfhgsn3yhnmy2po66mur5fhb5hwoguzbgddjaoeygyj7y
+- valory/memeooorr_abci:0.1.0:bafybeiglup4lullo7sucusrm5hv2vvtg7ykcut7to4ajhufli6m7dmkpju
 handlers:
   abci:
     args: {}

--- a/packages/valory/skills/memeooorr_abci/skill.yaml
+++ b/packages/valory/skills/memeooorr_abci/skill.yaml
@@ -64,7 +64,7 @@ protocols:
 skills:
 - valory/abstract_round_abci:0.1.0:bafybeifkxnvvgsldkb4rgejsoon2mvrmrnl7asy2nhenwss7hpwg3myflu
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
-- valory/mech_interact_abci:0.1.0:bafybeic5xfxdod5l56o7aojdamojnvi562nql2mlah73bf47d4guz4xnwi
+- valory/mech_interact_abci:0.1.0:bafybeigv3h4xlkmaahlhhfpp7g6mmspuz7rsudlifhy3kjpvoumrqrioqa
 - valory/agent_db_abci:0.1.0:bafybeiagtellrrf6wkookqk6jjx3wgxts462u6xtifl7gojtulgwitejnu
 - valory/funds_manager:0.1.0:bafybeicfw7qjtnlcbw6awsvxdahqu42fxsfsd3wy7mbyhcbls4l5pee3by
 behaviours:

--- a/packages/valory/skills/memeooorr_chained_abci/skill.yaml
+++ b/packages/valory/skills/memeooorr_chained_abci/skill.yaml
@@ -27,9 +27,9 @@ skills:
 - valory/reset_pause_abci:0.1.0:bafybeifrnmlscfiki7wojs6zasppefupd2wkjyq6orhdllfppjud7isrxi
 - valory/transaction_settlement_abci:0.1.0:bafybeihizaapype5sz7vlosms3nfo6jzfj4ujycuf5uthviq2otvmw6f6m
 - valory/termination_abci:0.1.0:bafybeih6sa2ttcvvjk7rcfn7ure2ws23kcfufssb4qmluzcfvednkfpvoi
-- valory/memeooorr_abci:0.1.0:bafybeicaq6xx4jfhgsn3yhnmy2po66mur5fhb5hwoguzbgddjaoeygyj7y
-- valory/mech_interact_abci:0.1.0:bafybeic5xfxdod5l56o7aojdamojnvi562nql2mlah73bf47d4guz4xnwi
-- valory/agent_performance_summary_abci:0.1.0:bafybeif3kicomdovxotfeg67huyuy5kk4phge6riz6ucodefywueru7tsu
+- valory/memeooorr_abci:0.1.0:bafybeiglup4lullo7sucusrm5hv2vvtg7ykcut7to4ajhufli6m7dmkpju
+- valory/mech_interact_abci:0.1.0:bafybeigv3h4xlkmaahlhhfpp7g6mmspuz7rsudlifhy3kjpvoumrqrioqa
+- valory/agent_performance_summary_abci:0.1.0:bafybeibrbuttmxhunmdjrvibavtjpd7q4kiyezgpbrbvct6trdsuonkok4
 behaviours:
   main:
     args: {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ override-dependencies = ["cffi<2.1"]
 [tool.tomte]
 packages_paths = "packages/valory"
 upstream_pins = [
-    "valory-xyz/mech-interact@v0.32.7",
+    "valory-xyz/mech-interact@v0.32.8",
     "valory-xyz/genai@v7.2.2",
     "valory-xyz/kv-store@v0.7.1",
     "valory-xyz/funds-manager@v3.1.2",


### PR DESCRIPTION
## Summary

Bumps the `mech_interact_abci` third-party skill pin to v0.32.8 to pick up the fix that signs over the 32-byte IPFS multihash instead of the JSON body, restoring correct offchain `request_id` derivation.

**Upstream references**
- PR: https://github.com/valory-xyz/mech-interact/pull/114
- Release: https://github.com/valory-xyz/mech-interact/releases/tag/v0.32.8

## Files changed

- `packages/packages.json` - third_party `mech_interact_abci` bumped to `bafybeigv3h4xlkmaahlhhfpp7g6mmspuz7rsudlifhy3kjpvoumrqrioqa`; dev hashes re-locked for `memeooorr_abci`, `memeooorr_chained_abci`, `agent_performance_summary_abci`, `agent/memeooorr`, `service/memeooorr`.
- `pyproject.toml` - `[tool.tomte].upstream_pins` bumped `valory-xyz/mech-interact@v0.32.7` -> `v0.32.8` so `check-third-party-hashes` stays green.
- `packages/valory/agents/memeooorr/aea-config.yaml`, `packages/dvilela/services/memeooorr/service.yaml`, `packages/valory/skills/memeooorr_abci/skill.yaml`, `packages/valory/skills/memeooorr_chained_abci/skill.yaml`, `packages/valory/skills/agent_performance_summary_abci/skill.yaml` - hash rippling only from `autonomy packages lock`.

No consumer code edits are needed; this is a pure hash bump for the offchain `request_id` derivation fix.

## Test plan

- [x] `uv run autonomy packages sync --update-packages --third-party` -> pulled v0.32.8 skill from IPFS.
- [x] `uv run autonomy packages lock && uv run autonomy packages lock --check` -> `Verification successful`.
- [ ] CI green on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)